### PR TITLE
refactor: fix lance 6.0.0 import paths for Dataset, WriteMode, WriteParams, RecordBatchIterator

### DIFF
--- a/src/traits/lance.rs
+++ b/src/traits/lance.rs
@@ -1,10 +1,11 @@
 use crate::{StorageError, StorageResult};
+use arrow::record_batch::RecordBatchIterator;
 use arrow_array::RecordBatch;
 use log::{debug, info};
 
-use arrow_array::RecordBatchIterator;
 use futures::StreamExt;
-use lance::dataset::{Dataset, WriteMode, WriteParams};
+use lance::Dataset;
+use lance::dataset::{WriteMode, WriteParams};
 
 pub trait LanceStorage {
     /// Async helper: write a RecordBatch to a Lance dataset.


### PR DESCRIPTION
## Summary

Fixes all lance import paths to match the lance 6.0.0 public API, as audited against the [official lance 6.0.0 write/read examples](https://lance.org/examples/rust/write_read_dataset/).

Closes #32.

## Changes

### `src/traits/lance.rs`

| Import | Before | After | Reason |
|---|---|---|---|
| `Dataset` | `lance::dataset::Dataset` | `lance::Dataset` | Top-level re-export is the canonical public API in lance 6.0.0 |
| `RecordBatchIterator` | `arrow_array::RecordBatchIterator` | `arrow::record_batch::RecordBatchIterator` | Canonical path in arrow `^58.0.0`; matches lance 6.0.0 examples |
| `WriteMode`, `WriteParams` | `lance::dataset::{WriteMode, WriteParams}` | `lance::dataset::{WriteMode, WriteParams}` | **Unchanged** — path is stable |

### `src/lance_storage_graph.rs`

No import changes required — this file does not import `Dataset` directly and all `arrow` imports use `arrow::array::*` / `arrow::datatypes::*` which are unchanged in arrow `^58.0.0`.

## API verification

The lance 6.0.0 official example confirms the stable write pattern:

```rust
use arrow::record_batch::{RecordBatch, RecordBatchIterator};
use lance::Dataset;
use lance::dataset::{WriteMode, WriteParams};

let batches = RecordBatchIterator::new([Ok(batch)], schema.clone());
let write_params = WriteParams { mode: WriteMode::Overwrite, ..Default::default() };
Dataset::write(batches, data_path, Some(write_params)).await.unwrap();
```

And the stable read pattern:

```rust
let dataset = Dataset::open(data_path).await.unwrap();
let scanner = dataset.scan();
let mut batch_stream = scanner.try_into_stream().await.unwrap();
while let Some(batch) = batch_stream.next().await { ... }
```

Both match the patterns already used in this codebase — only the import paths needed correction.

## Testing

- [ ] `cargo check` passes
- [ ] `cargo test --all` passes
- [ ] CI green
