### PR TITLE
fix: typed StorageError instead of panics across save/load paths (#45-#55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## 0.13.1 (2026-09-01)
+
+Issues #45-#55: no more panics in library code; typed errors for all
+recoverable conditions.
+
+**Breaking**
+
+- `StorageError` is now `#[non_exhaustive]` and gains variants
+  `InvalidState`, `UnsupportedFormat`, `UnsupportedFiletype`,
+  `DimensionMismatch { expected, found }`, `Overflow` (#53). Downstream
+  `match` expressions need a wildcard arm.
+- `FileInfo::which_format` / `FileInfo::which_filetype` return
+  `StorageResult<String>` instead of panicking on unknown input (#45).
+- `FileInfo::new` returns `StorageResult<Self>`;
+  `Metadata::new_fileinfo` returns `StorageResult<FileInfo>` (#45).
+- `LanceStorageGraph` fields `_base`/`_name` renamed to `base`/`name`
+  (pub(crate) only, no public API impact) (#55).
+
+**Fixed**
+
+- `validate_initialized` returns `StorageError::InvalidState` on metadata
+  path mismatch instead of `assert_eq!`-panicking (#47).
+- `from_sparse_record_batch` returns `StorageError::DimensionMismatch`
+  instead of panicking on schema/storage metadata disagreement (#46).
+- `path_to_uri` propagates path resolution failures (permissions, symlink
+  loops) as `StorageError::Io`; only `NotFound` still falls back to the
+  given absolute path (fresh saves) (#48).
+- `save_index` / `save_centroid_map` reject `usize` values above `u32::MAX`
+  with `StorageError::Overflow` instead of silently truncating (#51).
+- `save_metadata` / `load_metadata` / `GeneMetadata::read` use `tokio::fs`
+  instead of blocking `std::fs` inside async fns (#49).
+- `load_dense_from_file` parquet path runs on `tokio::task::spawn_blocking`
+  instead of blocking the executor (#52).
+
+**Changed**
+
+- Duplicated save pattern across `save_lambdas`, `save_vector`,
+  `save_index`, `save_centroid_map`, `save_subcentroid_lambdas`,
+  `save_item_norms`, `save_cluster_assignments` consolidated into
+  `LanceStorage::save_primitive_column` (~150 lines removed) (#50).
+- README quickstart fixed (wrong imports, invalid tuple syntax, wrong
+  method order); equivalent example added as a run-on-every-`cargo test`
+  doc-test on `LanceStorageGraph` (#54).
+
 ## 0.13.0 (2026-09-01)
 
 **Breaking**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,7 +1879,7 @@ dependencies = [
 
 [[package]]
 name = "genegraph-storage"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "approx 0.5.1",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "genegraph-storage"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 description = "vector database: base Lance storage"
 authors = ["Lorenzo <tunedconsulting@gmail.com>"]
@@ -38,7 +38,7 @@ arrow = { version = "^58.0.0" }
 uuid = { version = "1.21.0", features = ["v4", "serde"] }
 futures = "0.3.32"
 url = "2.5.8"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs"] }
 parquet = { version = "^58.0.0" }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -19,17 +19,19 @@ A storage layer for:
 cargo add genegraph_storage
 ```
 
-Simple example:
+Simple example (kept in sync with the compile-checked doc-test on `LanceStorageGraph`):
 
 ```rust
-use genegraph_storage::lance::LanceStorage;
-use genegraph_storage::metadata::{FileInfo, GeneMetadata};
-use genegraph_storage::traits::StorageBackend;
+use genegraph_storage::lance_storage_graph::LanceStorageGraph;
+use genegraph_storage::metadata::GeneMetadata;
+use genegraph_storage::traits::backend::StorageBackend;
+use genegraph_storage::traits::metadata::Metadata;
+use smartcore::linalg::basic::arrays::{Array, Array2};
 use smartcore::linalg::basic::matrix::DenseMatrix;
 
 // instantiate a storage
-let storage = LanceStorage::new(
-    "/tmp".to_string_lossy().to_string(),
+let storage = LanceStorageGraph::new(
+    "/tmp".to_string(),
     "basic_test".to_string(),
 );
 
@@ -42,16 +44,15 @@ let dense: Vec<Vec<f64>> = vec![
     vec![0.05, 0.4, 0.2, 0.3, 0.7]
 ];
 
-let (nitems, nfeatures) = dense.len(), dense[0].len(); 
-let data =
-    DenseMatrix::<f64>::from_iterator(
-        dense.iter().flatten().map(|x| *x), nitems, nfeatures, 0);
+let (nitems, nfeatures) = (dense.len(), dense[0].len());
+let data = DenseMatrix::<f64>::from_iterator(
+    dense.iter().flatten().copied(), nitems, nfeatures, 0);
 
-// Save metadata FIRST to initialize the storage directory
-let md = GeneMetadata::seed_metadata(name, nitems, nfeatures, &storage.clone())
+// seed metadata FIRST to initialize the storage directory
+let md = GeneMetadata::seed_metadata("basic_test", nitems, nfeatures, &storage)
     .await
-    .unwrap()
-    .with_dimensions(nitems, nfeatures);
+    .unwrap();
+let md_path = storage.save_metadata(&md).await.unwrap();
 
 // your data is saved in an efficient format
 storage
@@ -60,7 +61,6 @@ storage
     .unwrap();
 
 // Loading back
-let md_path = storage.save_metadata(&md).await.unwrap();
 let loaded = storage.load_dense("my_dataset").await.unwrap();
 ```
 

--- a/src/lance_storage_graph.rs
+++ b/src/lance_storage_graph.rs
@@ -5,10 +5,9 @@
 //! - Callers (CLI, tests, services) are responsible for providing a Tokio runtime.
 
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
 use arrow::array::{Array as ArrowArray, Float64Array, UInt32Array};
-use arrow::datatypes::{DataType, Field, Schema};
+use arrow::datatypes::{DataType, Float64Type, Int64Type, UInt32Type};
 use arrow::record_batch::RecordBatch;
 use log::{debug, info};
 use smartcore::linalg::basic::arrays::Array;
@@ -22,15 +21,80 @@ use crate::traits::lance::LanceStorage;
 use crate::traits::metadata::Metadata;
 use crate::{StorageError, StorageResult};
 
+/// Checked `usize -> u32` conversion.
+///
+/// Values above `u32::MAX` must surface an error instead of being silently
+/// truncated into wrong stored data (issue #51).
+fn checked_u32_values(values: &[usize], what: &str) -> StorageResult<Vec<u32>> {
+    values
+        .iter()
+        .map(|&v| {
+            u32::try_from(v).map_err(|_| {
+                StorageError::Overflow(format!(
+                    "{} value {} exceeds u32::MAX and would be silently truncated",
+                    what, v
+                ))
+            })
+        })
+        .collect()
+}
+
 /// Lance-based storage backend for ArrowSpace graph embeddings.
 ///
 /// Stores dense and sparse matrices as Lance datasets using a columnar format
 /// (`row`, `col`, `value` for sparse; `col_*` for dense) schema for efficient
 /// random and columnar access.
+///
+/// Metadata must be seeded before any `save_*` call so the storage directory
+/// is initialized; the example below is executed as a doc-test on every
+/// `cargo test` run so it cannot go stale.
+///
+/// # Examples
+///
+/// ```
+/// use genegraph_storage::lance_storage_graph::LanceStorageGraph;
+/// use genegraph_storage::metadata::GeneMetadata;
+/// use genegraph_storage::traits::backend::StorageBackend;
+/// use genegraph_storage::traits::metadata::Metadata;
+/// use smartcore::linalg::basic::arrays::{Array, Array2};
+/// use smartcore::linalg::basic::matrix::DenseMatrix;
+///
+/// let base = std::env::temp_dir().join(format!("genegraph_doc_{}", std::process::id()));
+/// # tokio::runtime::Runtime::new().unwrap().block_on(async {
+/// let storage = LanceStorageGraph::new(
+///     base.to_string_lossy().to_string(),
+///     "doc_example".to_string(),
+/// );
+///
+/// // some 2D data
+/// let dense: Vec<Vec<f64>> = vec![vec![0.1, 0.4], vec![0.5, 0.2], vec![0.03, 0.8]];
+/// let (nitems, nfeatures) = (dense.len(), dense[0].len());
+/// let data = DenseMatrix::<f64>::from_iterator(
+///     dense.iter().flatten().copied(),
+///     nitems,
+///     nfeatures,
+///     0,
+/// );
+///
+/// // seed metadata FIRST to initialize the storage directory
+/// let md = GeneMetadata::seed_metadata("doc_example", nitems, nfeatures, &storage)
+///     .await
+///     .unwrap();
+/// let md_path = storage.save_metadata(&md).await.unwrap();
+///
+/// // your data is saved in an efficient Lance format
+/// storage.save_dense("my_dataset", &data, &md_path).await.unwrap();
+///
+/// // Loading back
+/// let loaded = storage.load_dense("my_dataset").await.unwrap();
+/// assert_eq!(loaded.shape(), (nitems, nfeatures));
+/// # });
+/// # std::fs::remove_dir_all(&base).ok();
+/// ```
 #[derive(Debug, Clone)]
 pub struct LanceStorageGraph {
-    pub(crate) _base: String,
-    pub(crate) _name: String,
+    pub(crate) base: String,
+    pub(crate) name: String,
 }
 
 impl LanceStorageGraph {
@@ -40,11 +104,11 @@ impl LanceStorageGraph {
     ///
     /// # Arguments
     ///
-    /// * `_base` - Base directory path for all storage files
-    /// * `_name` - Name prefix for this storage instance
-    pub fn new(_base: String, _name: String) -> Self {
-        info!("Creating LanceStorage at base={}, name={}", _base, _name);
-        Self { _base, _name }
+    /// * `base` - Base directory path for all storage files
+    /// * `name` - Name prefix for this storage instance
+    pub fn new(base: String, name: String) -> Self {
+        info!("Creating LanceStorage at base={}, name={}", base, name);
+        Self { base, name }
     }
 
     /// Spawn a LanceStorage from an existing seeded directory (with metadata.json)
@@ -73,25 +137,25 @@ impl LanceStorage for LanceStorageGraph {}
 
 impl StorageBackend for LanceStorageGraph {
     fn get_base(&self) -> String {
-        self._base.clone()
+        self.base.clone()
     }
 
     fn get_name(&self) -> String {
-        self._name.clone()
+        self.name.clone()
     }
 
     fn base_path(&self) -> PathBuf {
-        PathBuf::from(&self._base)
+        PathBuf::from(&self.base)
     }
 
     fn metadata_path(&self) -> PathBuf {
         self.base_path()
-            .join(format!("{}_metadata.json", self._name))
+            .join(format!("{}_metadata.json", self.name))
     }
 
     /// Converts the base path for the store to a `file://` URI for Lance.
     fn basepath_to_uri(&self) -> StorageResult<String> {
-        Self::path_to_uri(PathBuf::from(self._base.clone()).as_path())
+        Self::path_to_uri(PathBuf::from(self.base.clone()).as_path())
     }
 
     /// Save dense matrix using Lance-optimized vector format.
@@ -143,7 +207,7 @@ impl StorageBackend for LanceStorageGraph {
                     matrix.shape(),
                     None,
                     None,
-                ),
+                )?,
             );
             self.save_metadata(&md).await?;
             info!("Dense {} matrix saved successfully", key);
@@ -225,41 +289,58 @@ impl StorageBackend for LanceStorageGraph {
             }
             "parquet" => {
                 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
-                use std::fs::File;
 
-                // 1. Read from Parquet into a single RecordBatch
-                let file = File::open(path)
-                    .map_err(|e| StorageError::Io(format!("Failed to open parquet file: {}", e)))?;
+                // Parquet readers require a synchronous `Read` impl; run the
+                // blocking open/read/concat on the dedicated blocking pool so
+                // the async executor thread is not stalled (issue #52).
+                let owned_path = path.to_path_buf();
+                let combined =
+                    tokio::task::spawn_blocking(move || -> StorageResult<RecordBatch> {
+                        let file = std::fs::File::open(&owned_path).map_err(|e| {
+                            StorageError::Io(format!("Failed to open parquet file: {}", e))
+                        })?;
 
-                let builder = ParquetRecordBatchReaderBuilder::try_new(file).map_err(|e| {
-                    StorageError::Parquet(format!("Failed to create parquet reader: {}", e))
-                })?;
-                let mut reader = builder.build().map_err(|e| {
-                    StorageError::Parquet(format!("Failed to build parquet reader: {}", e))
-                })?;
+                        let builder =
+                            ParquetRecordBatchReaderBuilder::try_new(file).map_err(|e| {
+                                StorageError::Parquet(format!(
+                                    "Failed to create parquet reader: {}",
+                                    e
+                                ))
+                            })?;
+                        let reader = builder.build().map_err(|e| {
+                            StorageError::Parquet(format!("Failed to build parquet reader: {}", e))
+                        })?;
 
-                let mut batches = Vec::new();
-                #[allow(clippy::while_let_on_iterator)]
-                while let Some(batch) = reader.next() {
-                    let batch = batch.map_err(|e| {
-                        StorageError::Parquet(format!("Failed to read parquet batch: {}", e))
-                    })?;
-                    batches.push(batch);
-                }
+                        let batches: Vec<RecordBatch> =
+                            reader.collect::<Result<Vec<_>, _>>().map_err(|e| {
+                                StorageError::Parquet(format!(
+                                    "Failed to read parquet batch: {}",
+                                    e
+                                ))
+                            })?;
 
-                if batches.is_empty() {
-                    return Err(StorageError::Invalid(format!(
-                        "Empty parquet dataset at {:?}",
-                        path
-                    )));
-                }
+                        if batches.is_empty() {
+                            return Err(StorageError::Invalid(format!(
+                                "Empty parquet dataset at {:?}",
+                                owned_path
+                            )));
+                        }
 
-                let schema = batches[0].schema();
-                let combined = arrow::compute::concat_batches(&schema, &batches).map_err(|e| {
-                    StorageError::Parquet(format!("Failed to concatenate parquet batches: {}", e))
-                })?;
+                        let schema = batches[0].schema();
+                        arrow::compute::concat_batches(&schema, &batches).map_err(|e| {
+                            StorageError::Parquet(format!(
+                                "Failed to concatenate parquet batches: {}",
+                                e
+                            ))
+                        })
+                    })
+                    .await
+                    .map_err(|e| {
+                        StorageError::Io(format!("Parquet reader task failed: {}", e))
+                    })??;
 
                 // 2. Detect layout: vector (FixedSizeList) vs old wide columnar (col_* Float64)
+                let schema = combined.schema();
                 let fields = schema.fields();
                 let is_vector = fields.len() == 1
                     && matches!(
@@ -346,7 +427,7 @@ impl StorageBackend for LanceStorageGraph {
 
     fn file_path(&self, key: &str) -> PathBuf {
         self.base_path()
-            .join(format!("{}_{}.lance", self._name, key))
+            .join(format!("{}_{}.lance", self.name, key))
     }
 
     // =========
@@ -370,7 +451,7 @@ impl StorageBackend for LanceStorageGraph {
             path
         );
 
-        let filetype = FileInfo::which_filetype(key);
+        let filetype = FileInfo::which_filetype(key)?;
         {
             let mut metadata = self.load_metadata().await?;
             metadata = metadata.add_file(
@@ -381,7 +462,7 @@ impl StorageBackend for LanceStorageGraph {
                     (matrix.rows(), matrix.cols()),
                     Some(matrix.nnz()),
                     None,
-                ),
+                )?,
             );
             self.save_metadata(&metadata).await?;
 
@@ -397,7 +478,7 @@ impl StorageBackend for LanceStorageGraph {
         info!("Loading sparse {} matrix", key);
 
         let metadata = self.load_metadata().await?;
-        let filetype = FileInfo::which_filetype(key);
+        let filetype = FileInfo::which_filetype(key)?;
         let file_info = metadata
             .files
             .get(key)
@@ -425,37 +506,9 @@ impl StorageBackend for LanceStorageGraph {
     }
 
     async fn save_lambdas(&self, lambdas: &[f64], md_path: &Path) -> StorageResult<()> {
-        self.validate_initialized(md_path)?;
-        let key = "lambdas";
-        let path = self.file_path("lambdas");
         info!("Saving {} lambda values", lambdas.len());
-
-        let schema = Schema::new(vec![Field::new("lambda", DataType::Float64, false)]);
-        let batch = RecordBatch::try_new(
-            Arc::new(schema),
-            vec![Arc::new(Float64Array::from(lambdas.to_vec())) as _],
-        )
-        .map_err(|e| StorageError::Lance(e.to_string()))?;
-
-        {
-            let mut metadata = self.load_metadata().await?;
-            metadata = metadata.add_file(
-                key,
-                FileInfo::new(
-                    format!("{}_{}.lance", self.get_name(), key),
-                    "vector",
-                    (lambdas.len(), 1),
-                    None,
-                    None,
-                ),
-            );
-            self.save_metadata(&metadata).await?;
-
-            let uri = Self::path_to_uri(&path)?;
-            self.write_lance_batch_async(uri, batch).await?;
-        }
-        info!("Lambda values saved successfully");
-        Ok(())
+        self.save_primitive_column::<Float64Type>("lambdas", "lambda", lambdas.to_vec(), md_path)
+            .await
     }
 
     async fn load_lambdas(&self) -> StorageResult<Vec<f64>> {
@@ -476,65 +529,18 @@ impl StorageBackend for LanceStorageGraph {
     }
 
     async fn save_vector(&self, key: &str, vector: &[f64], md_path: &Path) -> StorageResult<()> {
-        self.validate_initialized(md_path)?;
-        let path = self.file_path(key);
         info!("Saving {} values for vector {}", vector.len(), key);
-
-        let schema = Schema::new(vec![Field::new("element", DataType::Float64, false)]);
-        let float64_array = Float64Array::from_iter_values::<Vec<f64>>(vector.into());
-        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(float64_array) as _])
-            .map_err(|e| StorageError::Lance(e.to_string()))?;
-
-        {
-            let mut metadata = self.load_metadata().await?;
-            metadata = metadata.add_file(
-                key,
-                FileInfo::new(
-                    format!("{}_{}.lance", self.get_name(), key),
-                    "vector",
-                    (vector.len(), 1),
-                    None,
-                    None,
-                ),
-            );
-            self.save_metadata(&metadata).await?;
-
-            let uri = Self::path_to_uri(&path)?;
-            self.write_lance_batch_async(uri, batch).await?;
-        }
-        info!("Index {} saved successfully", key);
-        Ok(())
+        self.save_primitive_column::<Float64Type>(key, "element", vector.to_vec(), md_path)
+            .await
     }
 
     async fn save_index(&self, key: &str, vector: &[usize], md_path: &Path) -> StorageResult<()> {
-        self.validate_initialized(md_path)?;
-        let path = self.file_path(key);
         info!("Saving {} values for index {}", vector.len(), key);
-
-        let schema = Schema::new(vec![Field::new("id", DataType::UInt32, false)]);
-        let uint32_array = UInt32Array::from_iter_values(vector.iter().map(|&x| x as u32));
-        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(uint32_array) as _])
-            .map_err(|e| StorageError::Lance(e.to_string()))?;
-
-        {
-            let mut metadata = self.load_metadata().await?;
-            metadata = metadata.add_file(
-                key,
-                FileInfo::new(
-                    format!("{}_{}.lance", self.get_name(), key),
-                    "vector",
-                    (vector.len(), 1),
-                    None,
-                    None,
-                ),
-            );
-            self.save_metadata(&metadata).await?;
-
-            let uri = Self::path_to_uri(&path)?;
-            self.write_lance_batch_async(uri, batch).await?;
-        }
-        info!("Index {} saved successfully", key);
-        Ok(())
+        // Checked cast: usize values above u32::MAX must not be silently
+        // truncated (issue #51).
+        let values = checked_u32_values(vector, "index")?;
+        self.save_primitive_column::<UInt32Type>(key, "id", values, md_path)
+            .await
     }
 
     async fn load_vector(&self, filename: &str) -> StorageResult<Vec<f64>> {
@@ -675,35 +681,12 @@ impl StorageBackend for LanceStorageGraph {
 
     /// Save centroid_map (item-to-centroid assignments)
     async fn save_centroid_map(&self, map: &[usize], md_path: &Path) -> StorageResult<()> {
-        self.validate_initialized(md_path)?;
-        let key = "centroid_map";
-        let path = self.file_path(key);
         info!("Saving {} centroid map entries", map.len());
-
-        let schema = Schema::new(vec![Field::new("centroid_id", DataType::UInt32, false)]);
-        let uint32_array = UInt32Array::from_iter_values(map.iter().map(|&x| x as u32));
-        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(uint32_array) as _])
-            .map_err(|e| StorageError::Lance(e.to_string()))?;
-
-        {
-            let mut metadata = self.load_metadata().await?;
-            metadata = metadata.add_file(
-                key,
-                FileInfo::new(
-                    format!("{}_{}.lance", self.get_name(), key),
-                    "vector",
-                    (map.len(), 1),
-                    None,
-                    None,
-                ),
-            );
-            self.save_metadata(&metadata).await?;
-
-            let uri = Self::path_to_uri(&path)?;
-            self.write_lance_batch_async(uri, batch).await?;
-        }
-        info!("Centroid map saved successfully");
-        Ok(())
+        // Checked cast: usize values above u32::MAX must not be silently
+        // truncated (issue #51).
+        let values = checked_u32_values(map, "centroid map")?;
+        self.save_primitive_column::<UInt32Type>("centroid_map", "centroid_id", values, md_path)
+            .await
     }
 
     /// Load centroid_map
@@ -726,40 +709,14 @@ impl StorageBackend for LanceStorageGraph {
 
     /// Save subcentroid_lambdas (tau values for subcentroids)
     async fn save_subcentroid_lambdas(&self, lambdas: &[f64], md_path: &Path) -> StorageResult<()> {
-        self.validate_initialized(md_path)?;
-        let key = "subcentroid_lambdas";
-        let path = self.file_path(key);
         info!("Saving {} subcentroid lambda values", lambdas.len());
-
-        let schema = Schema::new(vec![Field::new(
+        self.save_primitive_column::<Float64Type>(
+            "subcentroid_lambdas",
             "subcentroid_lambda",
-            DataType::Float64,
-            false,
-        )]);
-        let batch = RecordBatch::try_new(
-            Arc::new(schema),
-            vec![Arc::new(Float64Array::from(lambdas.to_vec())) as _],
+            lambdas.to_vec(),
+            md_path,
         )
-        .map_err(|e| StorageError::Lance(e.to_string()))?;
-        {
-            let mut metadata = self.load_metadata().await?;
-            metadata = metadata.add_file(
-                key,
-                FileInfo::new(
-                    format!("{}_{}.lance", self.get_name(), key),
-                    "vector",
-                    (lambdas.len(), 1),
-                    None,
-                    None,
-                ),
-            );
-            self.save_metadata(&metadata).await?;
-
-            let uri = Self::path_to_uri(&path)?;
-            self.write_lance_batch_async(uri, batch).await?;
-        }
-        info!("Subcentroid lambda values saved successfully");
-        Ok(())
+        .await
     }
 
     /// Load subcentroid_lambdas
@@ -808,7 +765,7 @@ impl StorageBackend for LanceStorageGraph {
                     subcentroids.shape(),
                     None,
                     None,
-                ),
+                )?,
             );
             self.save_metadata(&metadata).await?;
 
@@ -848,37 +805,14 @@ impl StorageBackend for LanceStorageGraph {
 
     /// Save item norms vector
     async fn save_item_norms(&self, item_norms: &[f64], md_path: &Path) -> StorageResult<()> {
-        self.validate_initialized(md_path)?;
-        let key = "item_norms";
-        let path = self.file_path(key);
         info!("Saving {} item norm values", item_norms.len());
-
-        let schema = Schema::new(vec![Field::new("norm", DataType::Float64, false)]);
-        let batch = RecordBatch::try_new(
-            Arc::new(schema),
-            vec![Arc::new(Float64Array::from(item_norms.to_vec())) as _],
+        self.save_primitive_column::<Float64Type>(
+            "item_norms",
+            "norm",
+            item_norms.to_vec(),
+            md_path,
         )
-        .map_err(|e| StorageError::Lance(e.to_string()))?;
-
-        {
-            let mut metadata = self.load_metadata().await?;
-            metadata = metadata.add_file(
-                key,
-                FileInfo::new(
-                    format!("{}_{}.lance", self.get_name(), key),
-                    "vector",
-                    (item_norms.len(), 1),
-                    None,
-                    None,
-                ),
-            );
-            self.save_metadata(&metadata).await?;
-
-            let uri = Self::path_to_uri(&path)?;
-            self.write_lance_batch_async(uri, batch).await?;
-        }
-        info!("Item norms saved successfully");
-        Ok(())
+        .await
     }
 
     /// Load item norms vector
@@ -904,9 +838,6 @@ impl StorageBackend for LanceStorageGraph {
         assignments: &[Option<usize>],
         md_path: &Path,
     ) -> StorageResult<()> {
-        self.validate_initialized(md_path)?;
-        let key = "cluster_assignments";
-        let path = self.file_path(key);
         info!("Saving {} cluster assignments", assignments.len());
 
         // Convert Option<usize> to i64 (-1 for None)
@@ -915,33 +846,13 @@ impl StorageBackend for LanceStorageGraph {
             .map(|opt| opt.map(|v| v as i64).unwrap_or(-1))
             .collect();
 
-        use arrow::array::Int64Array;
-        let schema = Schema::new(vec![Field::new("cluster_id", DataType::Int64, false)]);
-        let batch = RecordBatch::try_new(
-            Arc::new(schema),
-            vec![Arc::new(Int64Array::from(values)) as _],
+        self.save_primitive_column::<Int64Type>(
+            "cluster_assignments",
+            "cluster_id",
+            values,
+            md_path,
         )
-        .map_err(|e| StorageError::Lance(e.to_string()))?;
-
-        {
-            let mut metadata = self.load_metadata().await?;
-            metadata = metadata.add_file(
-                key,
-                FileInfo::new(
-                    format!("{}_{}.lance", self.get_name(), key),
-                    "vector",
-                    (assignments.len(), 1),
-                    None,
-                    None,
-                ),
-            );
-            self.save_metadata(&metadata).await?;
-
-            let uri = Self::path_to_uri(&path)?;
-            self.write_lance_batch_async(uri, batch).await?;
-        }
-        info!("Cluster assignments saved successfully");
-        Ok(())
+        .await
     }
 
     async fn load_cluster_assignments(&self) -> StorageResult<Vec<Option<usize>>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,11 @@ mod tests;
 use std::fmt;
 
 // Error Handling harness
+//
+// `#[non_exhaustive]` lets this crate add error variants in future releases
+// without breaking downstream `match` expressions that carry a wildcard arm.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum StorageError {
     Io(String),
     Serde(serde_json::Error),
@@ -17,6 +21,21 @@ pub enum StorageError {
     Invalid(String),
     Lance(String),
     QueryError(String),
+    /// A storage resource is in an unexpected state (e.g. the metadata path
+    /// passed to a `save_*` call does not match the instance metadata path).
+    InvalidState(String),
+    /// A filetype does not map to a known storage format.
+    UnsupportedFormat(String),
+    /// A key/filetype is not recognised as one of the supported file types.
+    UnsupportedFiletype(String),
+    /// Dimensions recorded in schema metadata do not match the dimensions
+    /// recorded in storage metadata.
+    DimensionMismatch {
+        expected: String,
+        found: String,
+    },
+    /// A numeric value exceeds the range of the storage type it is written to.
+    Overflow(String),
 }
 
 impl fmt::Display for StorageError {
@@ -28,6 +47,17 @@ impl fmt::Display for StorageError {
             StorageError::Invalid(msg) => write!(f, "Invalid data: {}", msg),
             StorageError::Lance(msg) => write!(f, "Lance error: {}", msg),
             StorageError::QueryError(msg) => write!(f, "Query error: {}", msg),
+            StorageError::InvalidState(msg) => write!(f, "Invalid state: {}", msg),
+            StorageError::UnsupportedFormat(msg) => write!(f, "Unsupported format: {}", msg),
+            StorageError::UnsupportedFiletype(msg) => write!(f, "Unsupported filetype: {}", msg),
+            StorageError::DimensionMismatch { expected, found } => {
+                write!(
+                    f,
+                    "Dimension mismatch: expected {}, found {}",
+                    expected, found
+                )
+            }
+            StorageError::Overflow(msg) => write!(f, "Overflow error: {}", msg),
         }
     }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -3,10 +3,10 @@
 use log::{debug, info};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::fs;
 use std::path::PathBuf;
 
 use crate::StorageError;
+use crate::StorageResult;
 use crate::traits::backend::StorageBackend;
 use crate::traits::metadata::Metadata;
 
@@ -27,47 +27,48 @@ pub struct FileInfo {
 
 impl FileInfo {
     /// Create a file spec to add to the persistence directory
+    ///
+    /// Fails with `StorageError::UnsupportedFormat` for unrecognised
+    /// filetypes instead of panicking (issue #45).
     pub fn new(
         filename: String,
         filetype: &str,
         data_shape: (usize, usize),
         nnz: Option<usize>,
         size_bytes: Option<u64>,
-    ) -> Self {
+    ) -> StorageResult<Self> {
         debug!(
             "FileInfo::new: filename={}, filetype={}, shape={}x{}, nnz={:?}",
             filename, filetype, data_shape.0, data_shape.1, nnz
         );
-        Self {
+        Ok(Self {
             filename,
             filetype: filetype.into(),
-            storage_format: Self::which_format(filetype),
+            storage_format: Self::which_format(filetype)?,
             rows: data_shape.0,
             cols: data_shape.1,
             nnz,
             size_bytes,
-        }
+        })
     }
 
     /// Assign the right format to the file type
-    pub fn which_format(filetype: &str) -> String {
+    pub fn which_format(filetype: &str) -> StorageResult<String> {
         match filetype {
-            "dense" => String::from("lance fixed-row"),
-            "sparse" => String::from("lance row-major"),
-            "vector" => String::from("lance row-major"),
-            _ => panic!("filetype not recognised {}", filetype),
+            "dense" => Ok(String::from("lance fixed-row")),
+            "sparse" => Ok(String::from("lance row-major")),
+            "vector" => Ok(String::from("lance row-major")),
+            other => Err(StorageError::UnsupportedFormat(other.to_string())),
         }
     }
 
     /// Assign the right filetype to the keyname of the file
-    pub fn which_filetype(filetype: &str) -> String {
+    pub fn which_filetype(filetype: &str) -> StorageResult<String> {
         match filetype {
-            "rawinput" | "sub_centroids" | "dense" => String::from("dense"),
-            "adjacency" | "laplacian" | "signals" | "sparse" => String::from("sparse"),
-            "lambdas" | "item_norms" | "norms" | "vector" => String::from("vector"),
-            _ => panic!(
-                "Wrong filetype: use specific types or generic ('dense', 'sparse', 'vector')"
-            ),
+            "rawinput" | "sub_centroids" | "dense" => Ok(String::from("dense")),
+            "adjacency" | "laplacian" | "signals" | "sparse" => Ok(String::from("sparse")),
+            "lambdas" | "item_norms" | "norms" | "vector" => Ok(String::from("vector")),
+            other => Err(StorageError::UnsupportedFiletype(other.to_string())),
         }
     }
 }
@@ -89,7 +90,9 @@ impl GeneMetadata {
     /// Read metadata file from JSON
     pub async fn read(path: PathBuf) -> Result<Self, StorageError> {
         info!("Reading metadata from {:?}", path);
-        let s = fs::read_to_string(path).map_err(|e| StorageError::Io(e.to_string()))?;
+        let s = tokio::fs::read_to_string(path)
+            .await
+            .map_err(|e| StorageError::Io(e.to_string()))?;
         let md: GeneMetadata = serde_json::from_str(&s).map_err(StorageError::Serde)?;
         info!("Metadata read successfully");
         Ok(md)
@@ -118,7 +121,7 @@ impl Metadata for GeneMetadata {
         data_shape: (usize, usize),
         nnz: Option<usize>,
         size_bytes: Option<u64>,
-    ) -> FileInfo {
+    ) -> StorageResult<FileInfo> {
         FileInfo::new(
             format!("{}_{}.lance", self.name_id, key),
             filetype,

--- a/src/tests/test_lance_layer.rs
+++ b/src/tests/test_lance_layer.rs
@@ -41,14 +41,22 @@ async fn init_test_builder(
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[should_panic]
 async fn test_no_metadata() {
     crate::tests::init();
     let name = "meta_layout";
     let (_, storage, data, _, _) = init_test_builder(name).await;
 
-    let path = storage.file_path("test");
-    storage.save_dense("rawinput", &data, &path).await.unwrap();
+    // Correct metadata path, but metadata was never seeded: the save must
+    // fail with an error instead of writing outside an initialized store.
+    let md_path = storage.metadata_path();
+    let err = storage
+        .save_dense("rawinput", &data, &md_path)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, StorageError::Invalid(_)),
+        "expected Invalid (metadata missing), got {err:?}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -138,19 +146,23 @@ async fn test_metadata_simple() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[should_panic]
 async fn test_lance_dense_missing_metadata() {
     crate::tests::init();
     let name = "missing_metadata";
-    let (_, storage, data, _, _) = init_test_builder(name).await;
+    let (base, storage, data, _, _) = init_test_builder(name).await;
 
-    // Use row-major ordering (true parameter)
-    let path = storage.file_path("dense");
-
-    storage
-        .save_dense("missing_data", &data, &path)
+    // A data file path is not a metadata path: validate_initialized must
+    // report the mismatch as an error instead of asserting (issue #47).
+    let wrong_path = storage.file_path("dense");
+    let err = storage
+        .save_dense("missing_data", &data, &wrong_path)
         .await
-        .unwrap();
+        .unwrap_err();
+    assert!(
+        matches!(err, StorageError::InvalidState(ref msg) if msg.contains(wrong_path.to_string_lossy().as_ref())),
+        "expected InvalidState (metadata path mismatch), got {err:?}"
+    );
+    drop(base);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -571,7 +583,8 @@ async fn test_lance_storage_spawn_metadata_consistency() {
             (200, 75),
             None,
             None,
-        ),
+        )
+        .expect("dense is a known filetype"),
     );
 
     storage
@@ -667,4 +680,284 @@ fn test_path_to_uri_absolute_missing_path_is_ok() {
         uri,
         "file:///tmp/genegraph-definitely-not-yet-written.lance"
     );
+}
+
+#[test]
+#[cfg(unix)]
+fn test_path_to_uri_unresolvable_path_returns_error() {
+    // Issue #48: a symlink loop makes canonicalize() fail with ELOOP (not
+    // NotFound). The failure must surface as an error instead of being
+    // silently replaced by the unresolved path.
+    let base = std::env::temp_dir().join(format!("gg_uri_loop_{}", uuid::Uuid::new_v4().simple()));
+    std::fs::create_dir_all(&base).unwrap();
+    // Self-referential symlink: canonicalize() fails with ELOOP (not NotFound)
+    std::os::unix::fs::symlink("loop", base.join("loop")).unwrap();
+    let path = base.join("loop");
+
+    let result = <LanceStorageGraph as StorageBackend>::path_to_uri(&path);
+    assert!(
+        result.is_err(),
+        "expected error for unresolvable path, got {:?}",
+        result
+    );
+
+    std::fs::remove_dir_all(&base).ok();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_from_sparse_batch_dimension_mismatch_returns_error() {
+    // Issue #46: schema metadata dimensions that disagree with storage
+    // metadata must produce a typed error, not a panic.
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use arrow::array::{Float64Array, UInt32Array};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+
+    crate::tests::init();
+    let name_id = "sparse_dim_mismatch";
+    let base = tmp_dir(name_id).await;
+    let storage = LanceStorageGraph::new(base.to_string_lossy().to_string(), name_id.to_string());
+
+    // Batch schema metadata claims a 5x5 matrix...
+    let mut schema_metadata = HashMap::new();
+    schema_metadata.insert("rows".to_string(), "5".to_string());
+    schema_metadata.insert("cols".to_string(), "5".to_string());
+    let schema = Schema::new(vec![
+        Field::new("row", DataType::UInt32, false),
+        Field::new("col", DataType::UInt32, false),
+        Field::new("value", DataType::Float64, false),
+    ])
+    .with_metadata(schema_metadata);
+    let batch = RecordBatch::try_new(
+        Arc::new(schema),
+        vec![
+            Arc::new(UInt32Array::from(vec![0u32, 1u32])) as _,
+            Arc::new(UInt32Array::from(vec![1u32, 2u32])) as _,
+            Arc::new(Float64Array::from(vec![1.0, 2.0])) as _,
+        ],
+    )
+    .unwrap();
+
+    // ...but storage metadata expects 10x10.
+    let result = storage.from_sparse_record_batch(batch, 10, 10);
+    assert!(
+        matches!(result, Err(StorageError::DimensionMismatch { .. })),
+        "expected DimensionMismatch, got {:?}",
+        result
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_save_index_rejects_values_exceeding_u32_max() {
+    // Issue #51: usize values above u32::MAX must not be silently truncated.
+    crate::tests::init();
+    let name_id = "index_overflow";
+    let (_, storage, _, _, _) = init_test_builder(name_id).await;
+
+    let md = GeneMetadata::seed_metadata(name_id, 1, 1, &storage)
+        .await
+        .unwrap();
+    let md_path = storage.save_metadata(&md).await.unwrap();
+
+    let too_big = u32::MAX as usize + 1;
+    let err = storage
+        .save_index("big_index", &[0, 1, too_big], &md_path)
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, StorageError::Overflow(ref msg) if msg.contains(&too_big.to_string())),
+        "expected Overflow error mentioning {}, got {:?}",
+        too_big,
+        err
+    );
+
+    // The failed save must not register anything in metadata
+    let md = storage.load_metadata().await.unwrap();
+    assert!(
+        !md.files.contains_key("big_index"),
+        "failed save must not register the file in metadata"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_save_centroid_map_rejects_values_exceeding_u32_max() {
+    // Issue #51: same checked-conversion contract as save_index.
+    crate::tests::init();
+    let name_id = "centroid_overflow";
+    let (_, storage, _, _, _) = init_test_builder(name_id).await;
+
+    let md = GeneMetadata::seed_metadata(name_id, 1, 1, &storage)
+        .await
+        .unwrap();
+    let md_path = storage.save_metadata(&md).await.unwrap();
+
+    let too_big = u32::MAX as usize + 7;
+    let err = storage
+        .save_centroid_map(&[0, 1, too_big], &md_path)
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, StorageError::Overflow(ref msg) if msg.contains(&too_big.to_string())),
+        "expected Overflow error mentioning {}, got {:?}",
+        too_big,
+        err
+    );
+
+    let md = storage.load_metadata().await.unwrap();
+    assert!(
+        !md.files.contains_key("centroid_map"),
+        "failed save must not register the file in metadata"
+    );
+}
+
+// ===== Issue #50 guard tests: round-trips that must keep working while the
+// duplicated save/load pattern is consolidated into a shared helper. =====
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_index_roundtrip() {
+    crate::tests::init();
+    let name_id = "index_roundtrip";
+    let (_, storage, data, _, _) = init_test_builder(name_id).await;
+    let (nitems, _) = data.shape();
+
+    let md = GeneMetadata::seed_metadata(name_id, nitems, 1, &storage)
+        .await
+        .unwrap();
+    let md_path = storage.save_metadata(&md).await.unwrap();
+
+    let index: Vec<usize> = (0..nitems).rev().collect();
+    storage
+        .save_index("ordering", &index, &md_path)
+        .await
+        .unwrap();
+
+    let loaded = storage.load_index("ordering").await.unwrap();
+    assert_eq!(loaded, index);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_centroid_map_roundtrip() {
+    crate::tests::init();
+    let name_id = "centroid_map_roundtrip";
+    let (_, storage, data, _, _) = init_test_builder(name_id).await;
+    let (nitems, _) = data.shape();
+
+    let md = GeneMetadata::seed_metadata(name_id, nitems, 1, &storage)
+        .await
+        .unwrap();
+    let md_path = storage.save_metadata(&md).await.unwrap();
+
+    let map: Vec<usize> = (0..nitems).map(|i| i % 5).collect();
+    storage.save_centroid_map(&map, &md_path).await.unwrap();
+
+    let loaded = storage.load_centroid_map().await.unwrap();
+    assert_eq!(loaded, map);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_item_norms_roundtrip() {
+    crate::tests::init();
+    let name_id = "item_norms_roundtrip";
+    let (_, storage, data, _, norms) = init_test_builder(name_id).await;
+    let (nitems, nfeatures) = data.shape();
+
+    let md = GeneMetadata::seed_metadata(name_id, nitems, nfeatures, &storage)
+        .await
+        .unwrap();
+    let md_path = storage.save_metadata(&md).await.unwrap();
+
+    storage.save_item_norms(&norms, &md_path).await.unwrap();
+
+    let loaded = storage.load_item_norms().await.unwrap();
+    assert_eq!(loaded.len(), norms.len());
+    for (a, b) in norms.iter().zip(loaded.iter()) {
+        assert_relative_eq!(a, b, epsilon = 1e-10);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_subcentroids_roundtrip() {
+    crate::tests::init();
+    let name_id = "subcentroids_roundtrip";
+    let (_, storage, data, _, _) = init_test_builder(name_id).await;
+    let (nitems, nfeatures) = data.shape();
+
+    let md = GeneMetadata::seed_metadata(name_id, nitems, nfeatures, &storage)
+        .await
+        .unwrap();
+    let md_path = storage.save_metadata(&md).await.unwrap();
+
+    let subcentroids = DenseMatrix::new(
+        3,
+        nfeatures,
+        (0..3 * nfeatures).map(|i| (i % 7) as f64 * 0.25).collect(),
+        true,
+    )
+    .unwrap();
+    storage
+        .save_subcentroids(&subcentroids, &md_path)
+        .await
+        .unwrap();
+
+    let loaded = storage.load_subcentroids().await.unwrap();
+    assert_eq!(loaded.len(), 3);
+    assert_eq!(loaded[0].len(), nfeatures);
+    for (r, row) in loaded.iter().enumerate() {
+        for (c, value) in row.iter().enumerate() {
+            assert_relative_eq!(value, subcentroids.get((r, c)), epsilon = 1e-10);
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_subcentroid_lambdas_roundtrip() {
+    crate::tests::init();
+    let name_id = "subcentroid_lambdas_roundtrip";
+    let (_, storage, data, _, _) = init_test_builder(name_id).await;
+    let (nitems, nfeatures) = data.shape();
+
+    let md = GeneMetadata::seed_metadata(name_id, nitems, nfeatures, &storage)
+        .await
+        .unwrap();
+    let md_path = storage.save_metadata(&md).await.unwrap();
+
+    let lambdas: Vec<f64> = (0..nitems).map(|i| i as f64 * 0.01).collect();
+    storage
+        .save_subcentroid_lambdas(&lambdas, &md_path)
+        .await
+        .unwrap();
+
+    let loaded = storage.load_subcentroid_lambdas().await.unwrap();
+    assert_eq!(loaded.len(), lambdas.len());
+    for (a, b) in lambdas.iter().zip(loaded.iter()) {
+        assert_relative_eq!(a, b, epsilon = 1e-10);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_cluster_assignments_roundtrip() {
+    crate::tests::init();
+    let name_id = "cluster_assignments_roundtrip";
+    let (_, storage, data, _, _) = init_test_builder(name_id).await;
+    let (nitems, nfeatures) = data.shape();
+
+    let md = GeneMetadata::seed_metadata(name_id, nitems, nfeatures, &storage)
+        .await
+        .unwrap();
+    let md_path = storage.save_metadata(&md).await.unwrap();
+
+    let assignments: Vec<Option<usize>> = (0..nitems)
+        .map(|i| if i % 4 == 3 { None } else { Some(i % 5) })
+        .collect();
+    storage
+        .save_cluster_assignments(&assignments, &md_path)
+        .await
+        .unwrap();
+
+    let loaded = storage.load_cluster_assignments().await.unwrap();
+    assert_eq!(loaded, assignments);
 }

--- a/src/tests/test_metadata.rs
+++ b/src/tests/test_metadata.rs
@@ -31,12 +31,16 @@ async fn test_metadata_roundtrip_basic() {
     // Add file entries to test HashMap serialization
     original_metadata.files.insert(
         "rawinput".to_string(),
-        original_metadata.new_fileinfo("rawinput", "dense", (500, 128), None, Some(65536)),
+        original_metadata
+            .new_fileinfo("rawinput", "dense", (500, 128), None, Some(65536))
+            .expect("dense is a known filetype"),
     );
 
     original_metadata.files.insert(
         "lambdas".to_string(),
-        original_metadata.new_fileinfo("lambdas", "vector", (500, 128), None, Some(65536)),
+        original_metadata
+            .new_fileinfo("lambdas", "vector", (500, 128), None, Some(65536))
+            .expect("vector is a known filetype"),
     );
 
     // Save metadata using StorageBackend trait
@@ -228,4 +232,112 @@ async fn test_metadata_read_nonexistent_file() {
         }
         _ => panic!("Expected StorageError::Io, got {:?}", result),
     }
+}
+
+// ===== Issue #47: validate_initialized must return an error, not assert_eq!-panic =====
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_validate_initialized_mismatched_md_path_returns_error() {
+    let name_id = "validate_mismatch";
+    let base_path = tmp_dir(name_id).await;
+    let storage =
+        LanceStorageGraph::new(base_path.to_string_lossy().to_string(), name_id.to_string());
+
+    let wrong_path = base_path.join("other_instance_metadata.json");
+    let result = storage.validate_initialized(&wrong_path);
+
+    match result {
+        Err(StorageError::InvalidState(msg)) => {
+            assert!(
+                msg.contains("mismatch"),
+                "message should mention the mismatch: {}",
+                msg
+            );
+            assert!(
+                msg.contains(&wrong_path.to_string_lossy().to_string()),
+                "message should include the found path: {}",
+                msg
+            );
+        }
+        other => panic!(
+            "expected StorageError::InvalidState for mismatched path, got {:?}",
+            other.err()
+        ),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_validate_initialized_matching_path_without_metadata_returns_invalid() {
+    let name_id = "validate_missing";
+    let base_path = tmp_dir(name_id).await;
+    let storage =
+        LanceStorageGraph::new(base_path.to_string_lossy().to_string(), name_id.to_string());
+
+    let result = storage.validate_initialized(&storage.metadata_path());
+    assert!(
+        matches!(result, Err(StorageError::Invalid(_))),
+        "expected Invalid (metadata missing), got {:?}",
+        result.err()
+    );
+}
+
+// ===== Issue #45: FileInfo classification must return errors, not panic =====
+
+#[test]
+fn test_which_format_maps_known_filetypes() {
+    assert_eq!(FileInfo::which_format("dense").unwrap(), "lance fixed-row");
+    assert_eq!(FileInfo::which_format("sparse").unwrap(), "lance row-major");
+    assert_eq!(FileInfo::which_format("vector").unwrap(), "lance row-major");
+}
+
+#[test]
+fn test_which_format_rejects_unknown_filetype_with_error() {
+    let result = FileInfo::which_format("bogus_format");
+    assert!(
+        matches!(result, Err(StorageError::UnsupportedFormat(ref s)) if s == "bogus_format"),
+        "expected UnsupportedFormat error, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_which_filetype_maps_known_keys() {
+    assert_eq!(FileInfo::which_filetype("rawinput").unwrap(), "dense");
+    assert_eq!(FileInfo::which_filetype("sub_centroids").unwrap(), "dense");
+    assert_eq!(FileInfo::which_filetype("adjacency").unwrap(), "sparse");
+    assert_eq!(FileInfo::which_filetype("laplacian").unwrap(), "sparse");
+    assert_eq!(FileInfo::which_filetype("signals").unwrap(), "sparse");
+    assert_eq!(FileInfo::which_filetype("lambdas").unwrap(), "vector");
+    assert_eq!(FileInfo::which_filetype("item_norms").unwrap(), "vector");
+    assert_eq!(FileInfo::which_filetype("norms").unwrap(), "vector");
+}
+
+#[test]
+fn test_which_filetype_rejects_unknown_key_with_error() {
+    let result = FileInfo::which_filetype("bogus_key");
+    assert!(
+        matches!(result, Err(StorageError::UnsupportedFiletype(ref s)) if s == "bogus_key"),
+        "expected UnsupportedFiletype error, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_fileinfo_new_rejects_unknown_filetype_with_error() {
+    let result = FileInfo::new("bogus.lance".to_string(), "bogus", (10, 10), None, None);
+    assert!(
+        matches!(result, Err(StorageError::UnsupportedFormat(_))),
+        "expected UnsupportedFormat error, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_fileinfo_new_accepts_known_filetype() {
+    let info = FileInfo::new("f.lance".to_string(), "dense", (4, 2), None, None)
+        .expect("dense is a known filetype");
+    assert_eq!(info.filetype, "dense");
+    assert_eq!(info.storage_format, "lance fixed-row");
+    assert_eq!(info.rows, 4);
+    assert_eq!(info.cols, 2);
 }

--- a/src/traits/backend.rs
+++ b/src/traits/backend.rs
@@ -5,7 +5,6 @@ use log::{debug, info, trace};
 use smartcore::linalg::basic::arrays::Array;
 use smartcore::linalg::basic::matrix::DenseMatrix;
 use sprs::{CsMat, TriMat};
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -118,10 +117,22 @@ pub trait StorageBackend: Send + Sync {
     ///
     /// The path must be absolute; relative paths are rejected instead of
     /// being silently joined against a guessed working directory.
-    /// Non-existing paths are allowed (saves write to fresh locations);
-    /// existing ones are canonicalised first.
+    /// Non-existing paths are allowed (saves write to fresh locations) and
+    /// fall back to the given absolute path; any other resolution failure
+    /// (permissions, symlink loops, ...) is surfaced as an error instead of
+    /// being silently replaced by the unresolved path.
     fn path_to_uri(path: &Path) -> StorageResult<String> {
-        let resolved = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        let resolved = match path.canonicalize() {
+            Ok(canonical) => canonical,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => path.to_path_buf(),
+            Err(e) => {
+                return Err(StorageError::Io(format!(
+                    "Failed to resolve path `{}`: {}",
+                    path.display(),
+                    e
+                )));
+            }
+        };
         if !resolved.is_absolute() {
             return Err(StorageError::Invalid(format!(
                 "cannot convert relative path {:?} to a file:// URI; pass an absolute path",
@@ -141,7 +152,14 @@ pub trait StorageBackend: Send + Sync {
     ///
     /// Returns `Ok(())` if metadata file exists, otherwise returns an error.
     fn validate_initialized(&self, md_path: &Path) -> StorageResult<()> {
-        assert_eq!(self.metadata_path(), *md_path);
+        let expected = self.metadata_path();
+        if expected != *md_path {
+            return Err(StorageError::InvalidState(format!(
+                "metadata path mismatch: expected `{}`, found `{}`",
+                expected.display(),
+                md_path.display()
+            )));
+        }
         if !md_path.exists() {
             return Err(StorageError::Invalid(format!(
                 "Storage not initialized: metadata file missing at {:?}. \
@@ -409,10 +427,16 @@ pub trait StorageBackend: Send + Sync {
             let schema_rows = rows_str.parse::<usize>().ok();
             let schema_cols = cols_str.parse::<usize>().ok();
             if schema_rows != Some(expected_rows) || schema_cols != Some(expected_cols) {
-                panic!(
-                    "Schema metadata dimensions ({:?}x{:?}) don't match storage metadata ({}x{})",
-                    schema_rows, schema_cols, expected_rows, expected_cols
-                );
+                return Err(StorageError::DimensionMismatch {
+                    expected: format!("{}x{}", expected_rows, expected_cols),
+                    found: match (schema_rows, schema_cols) {
+                        (Some(r), Some(c)) => format!("{}x{}", r, c),
+                        _ => format!(
+                            "unparseable schema metadata {:?}x{:?}",
+                            schema_rows, schema_cols
+                        ),
+                    },
+                });
             } else {
                 debug!(
                     "Schema metadata matches storage metadata: {}x{}",
@@ -489,9 +513,13 @@ pub trait StorageBackend: Send + Sync {
     async fn save_metadata(&self, metadata: &GeneMetadata) -> StorageResult<PathBuf> {
         let path = self.metadata_path();
         info!("Saving metadata to {:?}", path);
-        fs::create_dir_all(self.base_path()).map_err(|e| StorageError::Io(e.to_string()))?;
+        tokio::fs::create_dir_all(self.base_path())
+            .await
+            .map_err(|e| StorageError::Io(e.to_string()))?;
         let s = serde_json::to_string_pretty(metadata).map_err(StorageError::Serde)?;
-        fs::write(&path, s).map_err(|e| StorageError::Io(e.to_string()))?;
+        tokio::fs::write(&path, s)
+            .await
+            .map_err(|e| StorageError::Io(e.to_string()))?;
         info!("Metadata saved successfully");
         Ok(path)
     }
@@ -500,7 +528,9 @@ pub trait StorageBackend: Send + Sync {
     async fn load_metadata(&self) -> StorageResult<GeneMetadata> {
         let filename = self.metadata_path();
         info!("Loading metadata from {:?}", filename);
-        let s = fs::read_to_string(filename).map_err(|e| StorageError::Io(e.to_string()))?;
+        let s = tokio::fs::read_to_string(filename)
+            .await
+            .map_err(|e| StorageError::Io(e.to_string()))?;
         let md: GeneMetadata = serde_json::from_str(&s).map_err(StorageError::Serde)?;
         info!("Metadata loaded successfully");
         Ok(md)

--- a/src/traits/lance.rs
+++ b/src/traits/lance.rs
@@ -1,4 +1,8 @@
-use crate::{StorageError, StorageResult};
+use std::path::Path;
+use std::sync::Arc;
+
+use arrow::array::{ArrayRef, PrimitiveArray};
+use arrow::datatypes::{ArrowPrimitiveType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use arrow::record_batch::RecordBatchIterator;
 use log::{debug, info};
@@ -6,6 +10,11 @@ use log::{debug, info};
 use futures::StreamExt;
 use lance::Dataset;
 use lance::dataset::{WriteMode, WriteParams};
+
+use crate::metadata::FileInfo;
+use crate::traits::backend::StorageBackend;
+use crate::traits::metadata::Metadata;
+use crate::{StorageError, StorageResult};
 
 pub trait LanceStorage {
     /// Async helper: write a RecordBatch to a Lance dataset.
@@ -62,5 +71,52 @@ pub trait LanceStorage {
             combined.num_rows()
         );
         Ok(combined)
+    }
+
+    /// Writes a single-column primitive vector as a Lance dataset named
+    /// `<name>_<key>.lance` and registers it in the metadata files map under
+    /// `key` with filetype "vector" and shape (`<len>`, 1).
+    ///
+    /// Shared implementation for the scalar `save_*` methods (lambdas,
+    /// vectors, indices, norms, centroid maps, cluster assignments).
+    async fn save_primitive_column<T: ArrowPrimitiveType>(
+        &self,
+        key: &str,
+        field_name: &str,
+        values: Vec<T::Native>,
+        md_path: &Path,
+    ) -> StorageResult<()>
+    where
+        Self: StorageBackend,
+    {
+        self.validate_initialized(md_path)?;
+        let path = self.file_path(key);
+        let len = values.len();
+        info!("Saving {} values for {} (field {})", len, key, field_name);
+
+        let schema = Schema::new(vec![Field::new(field_name, T::DATA_TYPE, false)]);
+        let batch = RecordBatch::try_new(
+            Arc::new(schema),
+            vec![Arc::new(PrimitiveArray::<T>::from_iter_values(values)) as ArrayRef],
+        )
+        .map_err(|e| StorageError::Lance(e.to_string()))?;
+
+        let mut metadata = self.load_metadata().await?;
+        metadata = metadata.add_file(
+            key,
+            FileInfo::new(
+                format!("{}_{}.lance", self.get_name(), key),
+                "vector",
+                (len, 1),
+                None,
+                None,
+            )?,
+        );
+        self.save_metadata(&metadata).await?;
+
+        let uri = Self::path_to_uri(&path)?;
+        self.write_lance_batch_async(uri, batch).await?;
+        info!("Vector {} saved successfully", key);
+        Ok(())
     }
 }

--- a/src/traits/metadata.rs
+++ b/src/traits/metadata.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use crate::StorageError;
+use crate::StorageResult;
 use crate::metadata::FileInfo;
 use crate::metadata::GeneMetadata;
 use crate::traits::backend::StorageBackend;
@@ -18,7 +19,7 @@ pub trait Metadata {
         data_shape: (usize, usize),
         nnz: Option<usize>,
         size_bytes: Option<u64>,
-    ) -> FileInfo;
+    ) -> StorageResult<FileInfo>;
 
     /// Standard pipeline object
     async fn seed_metadata<B: StorageBackend>(


### PR DESCRIPTION
Fixes #45, fixes #46, fixes #47, fixes #48, fixes #49, fixes #50, fixes #51, fixes #52, fixes #53, fixes #54, fixes #55

### Checklist
- [x] My branch is up-to-date with development branch.
- [x] Everything works and tested on latest stable Rust.
- [x] Coverage and Linting have been applied (clippy 0 warnings, `cargo fmt` clean)

### Current behaviour
Several library paths `panic!`/`assert_eq!`/unwrap on recoverable conditions, crashing the host process: `FileInfo::which_format`/`which_filetype` (#45), schema/storage dimension mismatch in `from_sparse_record_batch` (#46), metadata path mismatch in `validate_initialized` (#47). `path_to_uri` silently masks path resolution failures (#48); `save_index`/`save_centroid_map` silently truncate `usize` above `u32::MAX` (#51). Metadata I/O and the parquet load path block the Tokio executor with `std::fs` (#49, #52). Seven `save_*` methods duplicate ~150 lines of identical batch/metadata/write logic (#50). `StorageError` is exhaustive, so adding variants is a semver break (#53). The README quickstart has wrong imports, invalid syntax and wrong method order (#54). `LanceStorageGraph` fields use a misleading `_` prefix (#55).

### New expected behaviour
- All recoverable failures return typed `StorageError`s; no `panic!` remains in library code paths.
- New `#[non_exhaustive] StorageError` variants: `InvalidState`, `UnsupportedFormat`, `UnsupportedFiletype`, `DimensionMismatch { expected, found }`, `Overflow` (#53).
- `path_to_uri` propagates resolution failures as `StorageError::Io`; only `NotFound` still falls back to the given absolute path (fresh saves) (#48).
- Metadata I/O uses `tokio::fs`; parquet decode runs on `tokio::task::spawn_blocking` (#49, #52).
- Scalar saves are thin wrappers over a shared `LanceStorage::save_primitive_column` helper (~150 lines removed) (#50).
- README quickstart matches a compile-checked doc-test on `LanceStorageGraph` that runs on every `cargo test` (#54).
- Internal fields renamed `_base`/`_name` -> `base`/`name` (#55).

### Change logs

#### Added
- Reproduction tests for every panic/silent-corruption bug (RED verified before the fix) (#45, #46, #47, #48, #51)
- Round-trip guard tests for `save_index`, `save_centroid_map`, `save_item_norms`, `save_subcentroids`, `save_subcentroid_lambdas`, `save_cluster_assignments` (#50)
- Doc-test example on `LanceStorageGraph`, mirroring the README quickstart (#54)
- Version bump to 0.13.1 with CHANGELOG entry (breaking changes documented for consumers)

#### Changed
- `FileInfo::which_format`/`which_filetype`/`new` and `Metadata::new_fileinfo` now return `StorageResult` (#45)
- `validate_initialized` returns `InvalidState` instead of `assert_eq!` (#47); `from_sparse_record_batch` returns `DimensionMismatch` instead of `panic!` (#46)
- `save_index`/`save_centroid_map` use checked `usize -> u32` conversion, erroring with `Overflow` (#51)
- Two `#[should_panic]` tests converted to typed-error assertions now that panics are gone (#47)
