### PR TITLE
feat(parquet): M2.5 — first-class parquet interop paths (#75)

### DIFF
--- a/src/lance_storage_graph.rs
+++ b/src/lance_storage_graph.rs
@@ -581,22 +581,26 @@ impl StorageBackend for LanceStorageGraph {
     ///
     /// Async test helper that avoids any internal blocking runtimes.
     async fn save_dense_to_file(data: &DenseMatrix<f64>, path: &Path) -> StorageResult<()> {
-        use tokio::fs as tokio_fs;
-
         info!("Saving dense matrix to file (async): {:?}", path);
 
-        // Ensure parent dir exists for the test file.
-        if let Some(parent) = path.parent() {
-            tokio_fs::try_exists(parent).await.map_err(|e| {
-                StorageError::Io(format!("Failed to create dir {:?}: {}", parent, e))
+        // Create missing parent directories instead of failing late in the
+        // format-specific writers.
+        let parent = path
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .ok_or_else(|| {
+                StorageError::Invalid(format!("path has no parent directory: {:?}", path))
             })?;
-        }
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| StorageError::Io(format!("create dir {:?}: {}", parent, e)))?;
+        let parent_str = parent
+            .to_str()
+            .ok_or_else(|| StorageError::Invalid(format!("non-UTF8 parent path for {:?}", path)))?
+            .to_string();
 
-        // Create a temporary storage only to store the file.
-        let tmp_storage = Self::new(
-            String::from(path.parent().unwrap().to_str().unwrap()),
-            String::from("tmp_storage"),
-        );
+        // Temporary storage, only used to build the record batch / write lance.
+        let tmp_storage = Self::new(parent_str, String::from("tmp_storage"));
 
         let extension = path
             .extension()
@@ -633,7 +637,6 @@ impl StorageBackend for LanceStorageGraph {
                 use parquet::file::properties::WriterProperties;
                 use std::fs::File;
 
-                // For tests we still use sync parquet writer; directory was created with tokio_fs.
                 let batch = tmp_storage.to_dense_record_batch(data)?;
                 debug!(
                     "Created RecordBatch with {} rows for Parquet",
@@ -648,26 +651,36 @@ impl StorageBackend for LanceStorageGraph {
                     )));
                 }
 
-                let file = File::create(path).map_err(|e| {
-                    StorageError::Io(format!("Failed to create parquet file: {}", e))
-                })?;
-
-                let props = WriterProperties::builder()
-                    .set_compression(parquet::basic::Compression::SNAPPY)
-                    .build();
-
-                let mut writer =
-                    ArrowWriter::try_new(file, batch.schema(), Some(props)).map_err(|e| {
-                        StorageError::Parquet(format!("Failed to create parquet writer: {}", e))
+                // The parquet writer is synchronous: run it on the blocking
+                // pool so the async executor thread is not stalled (see #52
+                // for the matching read path).
+                let owned_path = path.to_path_buf();
+                tokio::task::spawn_blocking(move || -> StorageResult<()> {
+                    let file = File::create(&owned_path).map_err(|e| {
+                        StorageError::Io(format!("Failed to create parquet file: {}", e))
                     })?;
 
-                writer
-                    .write(&batch)
-                    .map_err(|e| StorageError::Parquet(format!("Failed to write batch: {}", e)))?;
+                    let props = WriterProperties::builder()
+                        .set_compression(parquet::basic::Compression::SNAPPY)
+                        .build();
 
-                writer
-                    .close()
-                    .map_err(|e| StorageError::Parquet(format!("Failed to close writer: {}", e)))?;
+                    let mut writer = ArrowWriter::try_new(file, batch.schema(), Some(props))
+                        .map_err(|e| {
+                            StorageError::Parquet(format!("Failed to create parquet writer: {}", e))
+                        })?;
+
+                    writer.write(&batch).map_err(|e| {
+                        StorageError::Parquet(format!("Failed to write batch: {}", e))
+                    })?;
+
+                    writer.close().map_err(|e| {
+                        StorageError::Parquet(format!("Failed to close writer: {}", e))
+                    })?;
+
+                    Ok(())
+                })
+                .await
+                .map_err(|e| StorageError::Io(format!("parquet writer task failed: {}", e)))??;
 
                 info!("Saved dense matrix to Parquet: {} x {}", n_rows, n_cols);
                 Ok(())

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -5,6 +5,7 @@ mod test_lancefmt_conformance;
 mod test_lancefmt_gen;
 mod test_lancefmt_impl;
 mod test_metadata;
+mod test_parquet_io;
 
 use std::fs;
 use std::path::PathBuf;

--- a/src/tests/test_parquet_io.rs
+++ b/src/tests/test_parquet_io.rs
@@ -1,0 +1,154 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use arrow::array::{Array as ArrowArray, Float64Array};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use parquet::arrow::ArrowWriter;
+use smartcore::linalg::basic::arrays::Array;
+use smartcore::linalg::basic::matrix::DenseMatrix;
+
+use crate::StorageError;
+use crate::lance_storage_graph::LanceStorageGraph;
+use crate::traits::backend::StorageBackend;
+
+fn tmp_dir_sync(name: &str) -> PathBuf {
+    let mut d = std::env::temp_dir();
+    let unique = format!(
+        "{}_{}",
+        name,
+        uuid::Uuid::new_v4().to_string().replace('-', "")
+    );
+    d.push(format!(
+        "{}_{}",
+        unique,
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+    ));
+    std::fs::create_dir_all(&d).unwrap();
+    d
+}
+
+fn sample_matrix() -> DenseMatrix<f64> {
+    // 4 rows x 3 cols, distinct values
+    let data: Vec<f64> = (0..12).map(|i| i as f64 * 0.25 - 1.0).collect();
+    DenseMatrix::new(4, 3, data, true).unwrap()
+}
+
+fn assert_matrix_eq(a: &DenseMatrix<f64>, b: &DenseMatrix<f64>) {
+    assert_eq!(a.shape(), b.shape(), "shape mismatch");
+    let (rows, cols) = a.shape();
+    for r in 0..rows {
+        for c in 0..cols {
+            let (x, y) = (*a.get((r, c)), *b.get((r, c)));
+            assert!(
+                (x - y).abs() < 1e-12,
+                "value mismatch at ({r},{c}): {x} != {y}"
+            );
+        }
+    }
+}
+
+fn rt<F: std::future::Future>(fut: F) -> F::Output {
+    tokio::runtime::Runtime::new().unwrap().block_on(fut)
+}
+
+fn storage_for(dir: &Path) -> LanceStorageGraph {
+    LanceStorageGraph::new(dir.to_string_lossy().to_string(), "pq_test".to_string())
+}
+
+/// Round-trip through the vector layout (`vector: FixedSizeList<Float64>`),
+/// which is what `save_dense_to_file` writes.
+#[test]
+fn parquet_roundtrip_vector_layout() {
+    let data = sample_matrix();
+    let dir = tmp_dir_sync("pq_vector");
+    let path = dir.join("dense.parquet");
+
+    rt(LanceStorageGraph::save_dense_to_file(&data, &path)).expect("save parquet");
+    let loaded = rt(storage_for(&dir).load_dense_from_file(&path)).expect("load parquet");
+    assert_matrix_eq(&data, &loaded);
+}
+
+/// Round-trip through the legacy wide layout (`col_0..col_N` Float64 columns).
+#[test]
+fn parquet_roundtrip_wide_layout() {
+    let data = sample_matrix();
+    let dir = tmp_dir_sync("pq_wide");
+    let path = dir.join("wide.parquet");
+
+    // Hand-write the wide layout: one Float64 column per matrix column.
+    let (rows, cols) = data.shape();
+    let fields: Vec<_> = (0..cols)
+        .map(|c| Field::new(format!("col_{c}"), DataType::Float64, false))
+        .collect();
+    let schema = Arc::new(Schema::new(fields));
+    let mut columns: Vec<Arc<dyn ArrowArray>> = Vec::with_capacity(cols);
+    for c in 0..cols {
+        let values: Vec<f64> = (0..rows).map(|r| *data.get((r, c))).collect();
+        columns.push(Arc::new(Float64Array::from(values)));
+    }
+    let batch = RecordBatch::try_new(schema, columns).unwrap();
+
+    let file = std::fs::File::create(&path).unwrap();
+    let mut writer = ArrowWriter::try_new(file, batch.schema(), None).unwrap();
+    writer.write(&batch).unwrap();
+    writer.close().unwrap();
+
+    let loaded = rt(storage_for(&dir).load_dense_from_file(&path)).expect("load wide parquet");
+    assert_matrix_eq(&data, &loaded);
+}
+
+/// Parquet files whose schema matches neither supported layout must be
+/// rejected with a typed error.
+#[test]
+fn parquet_rejects_unsupported_schema() {
+    let dir = tmp_dir_sync("pq_bad");
+    let path = dir.join("strings.parquet");
+
+    let schema = Arc::new(Schema::new(vec![Field::new("name", DataType::Utf8, false)]));
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![Arc::new(arrow::array::StringArray::from(vec!["a", "b"]))],
+    )
+    .unwrap();
+    let file = std::fs::File::create(&path).unwrap();
+    let mut writer = ArrowWriter::try_new(file, batch.schema(), None).unwrap();
+    writer.write(&batch).unwrap();
+    writer.close().unwrap();
+
+    let err = rt(storage_for(&dir).load_dense_from_file(&path)).unwrap_err();
+    assert!(
+        matches!(err, StorageError::Invalid(_)),
+        "expected Invalid for unsupported parquet schema, got {err:?}"
+    );
+}
+
+/// `save_dense_to_file` must create missing parent directories instead of
+/// failing with an IO error.
+#[test]
+fn parquet_save_creates_missing_parent_dir() {
+    let data = sample_matrix();
+    let dir = tmp_dir_sync("pq_mkdir");
+    let path = dir.join("a").join("b").join("dense.parquet");
+
+    rt(LanceStorageGraph::save_dense_to_file(&data, &path)).expect("save creates parents");
+    assert!(path.exists(), "parquet file must exist after save");
+    let loaded = rt(storage_for(&dir).load_dense_from_file(&path)).expect("reload");
+    assert_matrix_eq(&data, &loaded);
+}
+
+/// A path without a parent directory must produce an error, not a panic.
+#[test]
+#[cfg(unix)]
+fn parquet_save_root_path_returns_error() {
+    let data = sample_matrix();
+    let err = rt(LanceStorageGraph::save_dense_to_file(&data, Path::new("/")))
+        .expect_err("root path must error");
+    assert!(
+        matches!(err, StorageError::Invalid(_)),
+        "expected Invalid for parent-less path, got {err:?}"
+    );
+}

--- a/src/traits/backend.rs
+++ b/src/traits/backend.rs
@@ -108,6 +108,12 @@ pub trait StorageBackend: Send + Sync {
 
     /// Load initial data using columnar format from a file path.
     /// Implementations may use this as a helper for async `load_dense`.
+    ///
+    /// Supported parquet layouts: `vector: FixedSizeList<Float64>` (as
+    /// written by [`Self::save_dense_to_file`]) and the legacy wide layout
+    /// with `Float64` columns named `col_0..col_N`; anything else is rejected
+    /// with [`StorageError::Invalid`]. Supported lance layout: the vector
+    /// layout, read from the dataset directory at `path`.
     async fn load_dense_from_file(&self, path: &Path) -> StorageResult<DenseMatrix<f64>>;
 
     /// Compute the full Lance/parquet file path for a logical filetype.
@@ -583,5 +589,9 @@ pub trait StorageBackend: Send + Sync {
 
     async fn load_vector(&self, key: &str) -> StorageResult<Vec<f64>>;
 
+    /// Writes a dense matrix to `path` (`.lance` dataset directory or
+    /// `.parquet` file in the `vector: FixedSizeList<Float64>` layout, the
+    /// counterpart of [`Self::load_dense_from_file`]). Parent directories are
+    /// created as needed.
     async fn save_dense_to_file(data: &DenseMatrix<f64>, path: &Path) -> StorageResult<()>;
 }


### PR DESCRIPTION
Part of #75 (M2.5 — parquet interop promotion). Based on #78 (merged).

### Checklist
- [x] My branch is up-to-date with development branch.
- [x] Everything works and tested on latest stable Rust.
- [x] Coverage and Linting have been applied (clippy 0 warnings, `cargo fmt` clean)

### Current behaviour
`save_dense_to_file` wrote parquet with a synchronous `File::create` + `ArrowWriter` inside an async fn (blocking the Tokio executor — the write-path twin of #52, which fixed the read path), no-op'd on missing parent directories via `try_exists` and panicked on parent-less/non-UTF8 paths through raw `unwrap`s. The supported parquet layouts were undocumented, and no tests covered the parquet round-trip at all.

### New expected behaviour
- Parquet write runs on `tokio::task::spawn_blocking` — parity with the read path
- Missing parent directories are created (`tokio::fs::create_dir_all`); parent-less and non-UTF8 paths return `StorageError::Invalid` instead of panicking
- Supported layouts documented on `StorageBackend::save_dense_to_file` / `load_dense_from_file`: `vector: FixedSizeList<Float64>` (what we write) and the legacy wide `col_0..col_N` Float64 layout; anything else rejected with `StorageError::Invalid`
- 5 tests (TDD: the parent-dir and parent-less tests were verified RED first): vector-layout round-trip, wide-layout round-trip, unsupported-schema rejection, parent-dir creation, parent-less path error

### Change logs

#### Added
- `tests::test_parquet_io` suite (5 tests) covering both supported layouts and error paths (#75 M2.5)

#### Changed
- `save_dense_to_file` parquet branch now runs on the blocking pool; parent-dir handling rewritten with typed errors

#### Fixed
- Panic on parent-less/non-UTF8 paths in `save_dense_to_file`
