### PR TITLE
feat: transactional generations — atomic metadata commit, generation helpers (#93, RFC #81-P5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.26.0 (2026-09-02)
+
+Transactional generations: the durability layer for append-style writers
+(genegraph-storage #93, RFC #81 phase P5). Lessons taken from
+Migorithm/duva: immutable segments + a single atomic commit pointer.
+
+**Added**
+
+- `generations` module: `{logical}__g{N}` generation naming/parse helpers,
+  `list_generations` (committed only — a generation without a metadata
+  file was never committed), `list_artifact_generations` (committed +
+  orphaned, for sweeps), `delete_generation` (prefix-exact removal of a
+  generation's artifacts and metadata), `write_json_atomic` (tmp + fsync +
+  rename — the only sanctioned way to publish a metadata file).
+- `LanceStorageGraph::scoped_generation(n)`: a handle routing artifact IO
+  at `{logical}__g{n}_{key}.lance` with the per-generation metadata file
+  as commit pointer; logical identity recoverable via
+  `generations::logical_name`.
+
+**Changed**
+
+- `StorageBackend::save_metadata` (default impl) now publishes atomically
+  via `write_json_atomic` instead of an in-place write that could be
+  observed half-written after a crash.
+
 ## 0.25.0 (2026-09-02)
 
 Version line for the post-M5 development cycle (in-house Lance v2.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "genegraph-storage"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2024"
 description = "vector database: base Lance storage"
 authors = ["Lorenzo <tunedconsulting@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "genegraph-storage"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2024"
 description = "vector database: base Lance storage"
 authors = ["Lorenzo <tunedconsulting@gmail.com>"]

--- a/src/generations.rs
+++ b/src/generations.rs
@@ -1,0 +1,183 @@
+//! # Transactional generations (genegraph-storage #93, RFC #81 phase P5).
+//!
+//! Artifact generations are **immutable**: every publish (build, append,
+//! recompute) mints a fresh generation `{logical}__g{N}` — its artifacts are
+//! written once and never overwritten — and commits by atomically publishing
+//! the generation's metadata JSON (the single commit pointer, mirroring the
+//! snapshot/consensus-index pattern of segmented logs).
+//!
+//! Invariants:
+//! - A generation without a metadata file **was never committed**: readers
+//!   and discovery ignore it; the sweep API sees it for garbage collection.
+//! - The commit itself is a single atomic filesystem operation
+//!   ([`write_json_atomic`]): readers observe either the previous file or
+//!   the complete new one, never a partial write.
+//! - `__g{digits}` at the end of an instance name is reserved.
+
+use std::path::{Path, PathBuf};
+
+use crate::{StorageError, StorageResult};
+
+/// Separator between a logical dataset name and its generation number.
+pub const GENERATION_SEP: &str = "__g";
+
+/// Logical dataset name: strips a trailing `__g{digits}` generation suffix.
+pub fn logical_name(name: &str) -> &str {
+    if let Some(pos) = name.rfind(GENERATION_SEP) {
+        let suffix = &name[pos + GENERATION_SEP.len()..];
+        if !suffix.is_empty() && suffix.bytes().all(|b| b.is_ascii_digit()) {
+            return &name[..pos];
+        }
+    }
+    name
+}
+
+/// Generation-qualified instance name: `{logical}__g{gen}`.
+pub fn generation_name(logical: &str, generation: u64) -> String {
+    format!("{logical}{GENERATION_SEP}{generation}")
+}
+
+/// Parse the generation number out of a gen-qualified instance name.
+/// Returns `None` for plain logical names or malformed suffixes.
+pub fn parse_generation(name: &str) -> Option<u64> {
+    let pos = name.rfind(GENERATION_SEP)?;
+    let suffix = &name[pos + GENERATION_SEP.len()..];
+    if suffix.is_empty() || !suffix.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    suffix.parse().ok()
+}
+
+/// A committed generation: its number and the metadata file that pins it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenerationInfo {
+    pub generation: u64,
+    pub metadata_path: PathBuf,
+}
+
+/// Committed generations of `logical` under `base`, ascending by generation
+/// number. A generation is committed iff its `{logical}__g{N}_metadata.json`
+/// exists; pre-commit crash residue is invisible here.
+pub async fn list_generations(base: &Path, logical: &str) -> StorageResult<Vec<GenerationInfo>> {
+    let mut out = Vec::new();
+    for (generation, metadata_path) in scan_generation_paths(base, logical).await? {
+        if metadata_path.is_file() {
+            out.push(GenerationInfo {
+                generation,
+                metadata_path,
+            });
+        }
+    }
+    out.sort_by_key(|g| g.generation);
+    Ok(out)
+}
+
+/// Generation numbers with **any** artifact present under `base`, committed
+/// or not (orphans from a pre-commit crash included), ascending.
+pub async fn list_artifact_generations(base: &Path, logical: &str) -> StorageResult<Vec<u64>> {
+    let mut gens = std::collections::BTreeSet::new();
+    let mut rd = tokio::fs::read_dir(base)
+        .await
+        .map_err(|e| StorageError::Io(e.to_string()))?;
+    let artifact_prefix = format!("{logical}{GENERATION_SEP}");
+    while let Some(entry) = rd
+        .next_entry()
+        .await
+        .map_err(|e| StorageError::Io(e.to_string()))?
+    {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        let Some(rest) = name.strip_prefix(&artifact_prefix) else {
+            continue;
+        };
+        let Some(num) = rest.split('_').next() else {
+            continue;
+        };
+        if !num.is_empty() && num.bytes().all(|b| b.is_ascii_digit()) {
+            gens.insert(num.parse::<u64>().unwrap_or(u64::MAX));
+        }
+    }
+    Ok(gens.into_iter().collect())
+}
+
+/// Delete every file of a generation — artifacts and, if present, the
+/// metadata commit pointer. Prefix matching is exact on
+/// `{logical}__g{gen}_`, so sibling datasets (`ds` vs `ds2`) are untouched.
+/// Safe to call on orphaned generations (no metadata) and on missing ones.
+pub async fn delete_generation(base: &Path, logical: &str, generation: u64) -> StorageResult<()> {
+    let prefix = format!("{logical}{GENERATION_SEP}{generation}_");
+    let mut rd = tokio::fs::read_dir(base)
+        .await
+        .map_err(|e| StorageError::Io(e.to_string()))?;
+    while let Some(entry) = rd
+        .next_entry()
+        .await
+        .map_err(|e| StorageError::Io(e.to_string()))?
+    {
+        if !entry.file_name().to_string_lossy().starts_with(&prefix) {
+            continue;
+        }
+        let path = entry.path();
+        if path.is_dir() {
+            tokio::fs::remove_dir_all(&path)
+                .await
+                .map_err(|e| StorageError::Io(e.to_string()))?;
+        } else {
+            tokio::fs::remove_file(&path)
+                .await
+                .map_err(|e| StorageError::Io(e.to_string()))?;
+        }
+    }
+    Ok(())
+}
+
+/// Atomic JSON publish: write to `{path}.tmp`, fsync, rename over `path`.
+///
+/// The rename is the single commit point (POSIX-atomic within a directory):
+/// concurrent readers observe either the previous file or the complete new
+/// one, never a truncated write. This is the ONLY sanctioned way to publish
+/// a metadata file.
+pub fn write_json_atomic(path: &Path, contents: &str) -> StorageResult<()> {
+    use std::io::Write;
+
+    let tmp = path.with_extension("json.tmp");
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| StorageError::Io(e.to_string()))?;
+    }
+    {
+        let mut f = std::fs::File::create(&tmp).map_err(|e| StorageError::Io(e.to_string()))?;
+        f.write_all(contents.as_bytes())
+            .map_err(|e| StorageError::Io(e.to_string()))?;
+        f.sync_all().map_err(|e| StorageError::Io(e.to_string()))?;
+    }
+    std::fs::rename(&tmp, path).map_err(|e| StorageError::Io(e.to_string()))?;
+    Ok(())
+}
+
+/// `(generation, metadata_path)` pairs implied by `{logical}__g{N}_metadata.json`
+/// names under `base` (the file itself may or may not exist).
+async fn scan_generation_paths(base: &Path, logical: &str) -> StorageResult<Vec<(u64, PathBuf)>> {
+    let mut out = Vec::new();
+    let mut rd = tokio::fs::read_dir(base)
+        .await
+        .map_err(|e| StorageError::Io(e.to_string()))?;
+    let prefix = format!("{logical}{GENERATION_SEP}");
+    while let Some(entry) = rd
+        .next_entry()
+        .await
+        .map_err(|e| StorageError::Io(e.to_string()))?
+    {
+        let name = entry.file_name();
+        let name = name.to_string_lossy().into_owned();
+        let Some(rest) = name.strip_prefix(&prefix) else {
+            continue;
+        };
+        let Some(meta) = rest.strip_suffix("_metadata.json") else {
+            continue;
+        };
+        if !meta.is_empty() && meta.bytes().all(|b| b.is_ascii_digit()) {
+            out.push((meta.parse().unwrap_or(u64::MAX), entry.path()));
+        }
+    }
+    Ok(out)
+}

--- a/src/lance_storage_graph.rs
+++ b/src/lance_storage_graph.rs
@@ -131,6 +131,19 @@ impl LanceStorageGraph {
         let storage = Self::new(base_path.clone(), metadata.name_id.clone());
         Ok((storage, metadata))
     }
+
+    /// A handle over generation `gen` of this logical dataset: artifact
+    /// paths resolve as `{logical}__g{gen}_{key}.lance` and the metadata
+    /// path as `{logical}__g{gen}_metadata.json` — the per-generation
+    /// commit pointer (#93, RFC #81-P5). The logical identity stays
+    /// recoverable via [`crate::generations::logical_name`].
+    pub fn scoped_generation(&self, generation: u64) -> Self {
+        let logical = crate::generations::logical_name(&self.name);
+        Self::new(
+            self.base.clone(),
+            crate::generations::generation_name(logical, generation),
+        )
+    }
 }
 
 impl LanceStorage for LanceStorageGraph {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(async_fn_in_trait)]
 pub mod catalog;
+pub mod generations;
 pub mod lance_storage_graph;
 pub mod lancefmt;
 pub mod metadata;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,6 +1,7 @@
 mod lancefmt_common;
 mod test_catalog;
 mod test_data;
+mod test_generations;
 mod test_lance_layer;
 mod test_lancefmt_conformance;
 mod test_lancefmt_gen;

--- a/src/tests/test_generations.rs
+++ b/src/tests/test_generations.rs
@@ -1,0 +1,179 @@
+//! #93 / RFC #81-P5: transactional generations.
+//!
+//! Artifact generations are immutable: every append mints `{logical}__g{N}`
+//! artifact paths and commits by atomically publishing the generation's
+//! metadata JSON (the single commit pointer). A generation without a
+//! metadata file was never committed and is invisible to readers.
+
+use std::fs;
+use std::path::Path;
+
+use crate::generations::{
+    GenerationInfo, generation_name, list_artifact_generations, list_generations, logical_name,
+    parse_generation, write_json_atomic,
+};
+use crate::lance_storage_graph::LanceStorageGraph;
+use crate::traits::backend::StorageBackend;
+
+use super::tmp_dir;
+
+/// `{logical}__g{N}` is reserved: logical names round-trip, generations parse.
+#[test]
+fn test_generation_naming_roundtrip() {
+    assert_eq!(generation_name("ds_ab12", 0), "ds_ab12__g0");
+    assert_eq!(generation_name("ds_ab12", 17), "ds_ab12__g17");
+    assert_eq!(logical_name("ds_ab12__g17"), "ds_ab12");
+    assert_eq!(logical_name("ds_ab12__g0"), "ds_ab12");
+    assert_eq!(logical_name("ds_ab12"), "ds_ab12", "no suffix = logical");
+    assert_eq!(parse_generation("ds_ab12__g17"), Some(17));
+    assert_eq!(parse_generation("ds_ab12"), None);
+    assert_eq!(parse_generation("ds_ab12__g1x"), None, "non-digit suffix");
+    // names that merely contain the separator mid-name are left alone
+    assert_eq!(logical_name("ds__g1x"), "ds__g1x");
+    // double suffix strips the last generation only
+    assert_eq!(logical_name("ds__g1__g2"), "ds__g1");
+    assert_eq!(parse_generation("ds__g1__g2"), Some(2));
+}
+
+/// Atomic publish: the file always holds a complete document, overwrites
+/// work, and no `.tmp` residue remains.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_write_json_atomic_overwrites_completely() {
+    let dir = tmp_dir("test_write_json_atomic_overwrites_completely").await;
+    let path = dir.join("ds__g1_metadata.json");
+
+    write_json_atomic(&path, r#"{"v": 1}"#).expect("first publish must succeed");
+    assert_eq!(fs::read_to_string(&path).unwrap(), r#"{"v": 1}"#);
+
+    // overwrite with a longer document: no truncation window residue
+    write_json_atomic(&path, r#"{"v": 2, "files": {"rawinput": {}}}"#)
+        .expect("republish must succeed");
+    assert_eq!(
+        fs::read_to_string(&path).unwrap(),
+        r#"{"v": 2, "files": {"rawinput": {}}}"#
+    );
+
+    let residue: Vec<_> = fs::read_dir(&dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|x| x == "tmp"))
+        .collect();
+    assert!(residue.is_empty(), "tmp files must not leak: {residue:?}");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// Only generations with a metadata file are committed/listed; artifact
+/// generations without one (orphans from a pre-commit crash) are visible
+/// to the sweep API but never to resolution.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_list_generations_ignores_orphans() {
+    let dir = tmp_dir("test_list_generations_ignores_orphans").await;
+
+    // committed gen 1 and gen 3, orphaned artifacts of gen 2
+    for (generation, rows) in [(1u64, 10usize), (3, 30)] {
+        write_json_atomic(
+            &dir.join(format!("ds__g{generation}_metadata.json")),
+            &format!(r#"{{"nrows": {rows}}}"#),
+        )
+        .unwrap();
+    }
+    fs::create_dir_all(dir.join("ds__g2_rawinput.lance")).unwrap();
+
+    let committed = list_generations(Path::new(&dir), "ds").await.unwrap();
+    assert_eq!(
+        committed,
+        vec![
+            GenerationInfo {
+                generation: 1,
+                metadata_path: dir.join("ds__g1_metadata.json")
+            },
+            GenerationInfo {
+                generation: 3,
+                metadata_path: dir.join("ds__g3_metadata.json")
+            },
+        ],
+        "ascending, committed only"
+    );
+
+    let artifacts = list_artifact_generations(Path::new(&dir), "ds")
+        .await
+        .unwrap();
+    assert_eq!(artifacts, vec![1, 2, 3], "orphans visible to the sweep");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// `delete_generation` removes the generation's artifacts and metadata;
+/// prefix matches must not leak into sibling datasets (`ds` vs `ds2`).
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delete_generation_is_prefix_exact() {
+    let dir = tmp_dir("test_delete_generation_is_prefix_exact").await;
+
+    for name in ["ds__g1_rawinput.lance", "ds2__g1_rawinput.lance"] {
+        fs::create_dir_all(dir.join(name)).unwrap();
+    }
+    write_json_atomic(&dir.join("ds__g1_metadata.json"), "{}").unwrap();
+    write_json_atomic(&dir.join("ds2__g1_metadata.json"), "{}").unwrap();
+
+    crate::generations::delete_generation(Path::new(&dir), "ds", 1)
+        .await
+        .expect("delete must succeed");
+
+    assert!(!dir.join("ds__g1_rawinput.lance").exists());
+    assert!(!dir.join("ds__g1_metadata.json").exists());
+    assert!(
+        dir.join("ds2__g1_rawinput.lance").exists(),
+        "sibling intact"
+    );
+    assert!(dir.join("ds2__g1_metadata.json").exists(), "sibling intact");
+
+    // orphan sweep: deleting a never-committed generation is a no-op-safe path
+    fs::create_dir_all(dir.join("ds__g9_rawinput.lance")).unwrap();
+    crate::generations::delete_generation(Path::new(&dir), "ds", 9)
+        .await
+        .expect("orphan sweep must succeed");
+    assert!(!dir.join("ds__g9_rawinput.lance").exists());
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// A scoped handle routes artifact IO at the generation's paths while
+/// keeping the logical identity accessible.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_scoped_generation_routes_artifact_paths() {
+    let dir = tmp_dir("test_scoped_generation_routes_artifact_paths").await;
+    let storage = LanceStorageGraph::new(dir.to_string_lossy().to_string(), "ds".to_string())
+        .scoped_generation(3);
+
+    assert_eq!(storage.get_name(), "ds__g3");
+    assert_eq!(
+        storage.file_path("rawinput"),
+        dir.join("ds__g3_rawinput.lance")
+    );
+    assert_eq!(
+        storage.metadata_path(),
+        dir.join("ds__g3_metadata.json"),
+        "per-generation metadata = per-generation commit pointer"
+    );
+    assert_eq!(crate::generations::logical_name(&storage.get_name()), "ds");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// Generation 0 is the initial build: scoped_generation(0) equals a plain
+/// instance named `{logical}__g0` and the metadata path stays distinct.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_scoped_generation_zero_is_the_build_generation() {
+    let dir = tmp_dir("test_scoped_generation_zero_is_the_build_generation").await;
+    let storage = LanceStorageGraph::new(dir.to_string_lossy().to_string(), "ds".to_string())
+        .scoped_generation(0);
+
+    assert_eq!(
+        storage.file_path("lambdas"),
+        dir.join("ds__g0_lambdas.lance")
+    );
+    assert_eq!(storage.metadata_path(), dir.join("ds__g0_metadata.json"));
+
+    let _ = fs::remove_dir_all(&dir);
+}

--- a/src/traits/backend.rs
+++ b/src/traits/backend.rs
@@ -519,13 +519,10 @@ pub trait StorageBackend: Send + Sync {
     async fn save_metadata(&self, metadata: &GeneMetadata) -> StorageResult<PathBuf> {
         let path = self.metadata_path();
         info!("Saving metadata to {:?}", path);
-        tokio::fs::create_dir_all(self.base_path())
-            .await
-            .map_err(|e| StorageError::Io(e.to_string()))?;
         let s = serde_json::to_string_pretty(metadata).map_err(StorageError::Serde)?;
-        tokio::fs::write(&path, s)
-            .await
-            .map_err(|e| StorageError::Io(e.to_string()))?;
+        // Atomic publish (#93): tmp + fsync + rename — the file is the
+        // single commit pointer and must never be observed half-written.
+        crate::generations::write_json_atomic(&path, &s)?;
         info!("Metadata saved successfully");
         Ok(path)
     }


### PR DESCRIPTION
## Summary

Implements the durability layer for append-style writers (#93), proposed as **RFC #81 phase P5**. Lessons taken from Migorithm/duva (segmented log + snapshot/consensus-index): **immutable artifact generations + a single atomic commit pointer**.

- Every publish (build, append, recompute) mints generation `{logical}__g{N}`; its artifacts are written once and never overwritten.
- The generation's metadata JSON is the **commit pointer**, published atomically (`write_json_atomic`: tmp + fsync + rename). A generation without a metadata file was never committed — pre-commit crash residue is invisible to readers and swept by GC.
- Eliminates the *artifacts-ahead-of-metadata* window consumers currently must heal (see genefold-vd's P6b-for-append contract).

## Changes

- **`generations` module** (new): `generation_name`/`logical_name`/`parse_generation`, `list_generations` (committed only), `list_artifact_generations` (committed + orphaned, for sweeps), `delete_generation` (prefix-exact — `ds` vs `ds2` safe), `write_json_atomic`.
- **`LanceStorageGraph::scoped_generation(n)`**: handle routing artifact IO at `{logical}__g{n}_{key}.lance` with `{logical}__g{n}_metadata.json` as the per-generation commit pointer; logical identity recoverable.
- **`StorageBackend::save_metadata`** (default impl): atomic publish instead of in-place `fs::write`.
- Version 0.25.0 → 0.26.0; CHANGELOG entry.

## Tests

- 6 new tests: naming roundtrip, atomic overwrite (no `.tmp` residue), orphan visibility (committed vs sweep), prefix-exact delete, scoped artifact/metadata paths, generation 0.
- Full suite: 79 passed, 0 failed; `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt` applied.

## Relationship to RFC #81

Complements P1–P4 (data model): P1 collections give the metadata model a generation can point at; **FileInfo-driven reads** (this RFC's next step, tracked in #93) let one logical dataset own many generations under one canonical metadata file, consolidating identity beyond the interim one-metadata-file-per-generation model.

Closes #93