### PR TITLE
feat!: generic storage for vector spaces and graph data (RFC #81 P1-P4, 0.28.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS.md
+
+## Shell tools
+
+- Do not use perl for file editing/transformations. Use python3 (via `uv` if present), sed, awk and bash commands instead.
+
+## Build & test
+
+- Run cargo test always with the `--release` flag (e.g. `cargo test --release --lib`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "genegraph-storage"
-version = "0.25.0"
+version = "0.28.0"
 dependencies = [
  "approx 0.5.1",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "genegraph-storage"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2024"
 description = "vector database: base Lance storage"
 authors = ["Lorenzo <tunedconsulting@gmail.com>"]
@@ -18,7 +18,7 @@ exclude = [
     ".github/*",
     "*.tmp",
     "docs/*",
-    "becnhes/*",
+    "benches/*",
     "examples/*"
 
 ]
@@ -37,7 +37,7 @@ arrow = { version = "^58.0.0" }
 uuid = { version = "1.21.0", features = ["v4", "serde"] }
 futures = "0.3.32"
 url = "2.5.8"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs", "sync"] }
 parquet = { version = "^58.0.0" }
 prost = "0.14"
 prost-types = "0.14"

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -17,7 +17,19 @@ use std::path::PathBuf;
 
 use crate::StorageError;
 use crate::StorageResult;
+pub use crate::metadata::CollectionKind;
 use crate::metadata::{FileInfo, GeneMetadata};
+
+/// Computed descriptor properties that mirror `FileInfo` fields; user
+/// properties cannot shadow them.
+const RESERVED_PROPERTIES: [&str; 6] = [
+    "filetype",
+    "storage_format",
+    "rows",
+    "cols",
+    "nnz",
+    "size_bytes",
+];
 
 /// Generic Table API-compatible table descriptor.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -28,8 +40,25 @@ pub struct TableDescriptor {
     pub format: String,
     /// Location of the table root (a `*.lance` dataset directory).
     pub base_location: PathBuf,
-    /// Free-form key/value properties (filetype, shape, ...).
+    /// First-class collection kind (RFC #81-P1): `vector-space`, `graph` or
+    /// `table`.
+    pub kind: CollectionKind,
+    /// Free-form key/value properties (filetype, shape, ...), merged with
+    /// the collection's user properties (RFC #81-P1).
     pub properties: BTreeMap<String, String>,
+}
+
+/// Vector-space descriptor plus its linked graph collection (RFC #81-P4).
+///
+/// A vector space references a graph collection by name through its `graph`
+/// user property; [`Catalog::describe_vector_space`] resolves both in one
+/// call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VectorSpaceDescriptor {
+    /// The vector-space collection itself.
+    pub vectors: TableDescriptor,
+    /// The linked graph collection, if the `graph` property is set.
+    pub graph: Option<TableDescriptor>,
 }
 
 /// Registry of Lance tables backing a storage instance.
@@ -45,6 +74,25 @@ pub trait Catalog {
     fn register_table(&mut self, table: TableDescriptor) -> StorageResult<()>;
     /// Removes `name` from the registry without deleting the dataset.
     fn deregister_table(&mut self, name: &str) -> StorageResult<()>;
+
+    /// Describes a vector-space collection together with the graph
+    /// collection it references through the `graph` user property
+    /// (RFC #81-P4). Fails with [`StorageError::Invalid`] if `name` is not a
+    /// vector-space collection or the linked graph is not registered.
+    fn describe_vector_space(&self, name: &str) -> StorageResult<VectorSpaceDescriptor> {
+        let vectors = self.describe_table(name)?;
+        if vectors.kind != CollectionKind::VectorSpace {
+            return Err(StorageError::Invalid(format!(
+                "collection '{name}' has kind '{}', not a vector space",
+                vectors.kind.as_str()
+            )));
+        }
+        let graph = match vectors.properties.get("graph") {
+            Some(graph_name) => Some(self.describe_table(graph_name)?),
+            None => None,
+        };
+        Ok(VectorSpaceDescriptor { vectors, graph })
+    }
 }
 
 /// [`Catalog`] implementation over the existing JSON metadata registry.
@@ -76,6 +124,10 @@ impl LocalRegistry {
     }
 
     fn descriptor(&self, key: &str, info: &FileInfo) -> TableDescriptor {
+        let kind = info
+            .kind
+            .or_else(|| CollectionKind::for_filetype(&info.filetype))
+            .unwrap_or(CollectionKind::Table);
         let mut properties = BTreeMap::new();
         properties.insert("filetype".to_string(), info.filetype.clone());
         properties.insert("storage_format".to_string(), info.storage_format.clone());
@@ -87,10 +139,17 @@ impl LocalRegistry {
         if let Some(size) = info.size_bytes {
             properties.insert("size_bytes".to_string(), size.to_string());
         }
+        // User properties overlay the computed ones; `kind` is always the
+        // authoritative typed value.
+        for (k, v) in &info.properties {
+            properties.insert(k.clone(), v.clone());
+        }
+        properties.insert("kind".to_string(), kind.as_str().to_string());
         TableDescriptor {
             name: key.to_string(),
             format: "lance".to_string(),
             base_location: self.base.join(&info.filename),
+            kind,
             properties,
         }
     }
@@ -139,7 +198,22 @@ impl Catalog for LocalRegistry {
                 })
                 .transpose()
         };
-        let info = FileInfo::new(
+        // RFC #81-P1: an explicit `kind` property wins; otherwise the typed
+        // `kind` field is authoritative. Unknown kinds are rejected.
+        let kind = match prop("kind") {
+            Some(k) => Some(CollectionKind::parse(&k)?),
+            None => Some(table.kind),
+        };
+        // User properties (everything not computed above) are persisted on
+        // the FileInfo so they survive the descriptor -> registry -> describe
+        // round-trip.
+        let user_properties: BTreeMap<String, String> = table
+            .properties
+            .iter()
+            .filter(|(k, _)| !RESERVED_PROPERTIES.contains(&k.as_str()) && k.as_str() != "kind")
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        let mut info = FileInfo::new(
             table
                 .base_location
                 .file_name()
@@ -150,6 +224,8 @@ impl Catalog for LocalRegistry {
             parse("nnz")?,
             None,
         )?;
+        info.kind = kind;
+        info.properties = user_properties;
         self.metadata.files.insert(table.name, info);
         Ok(())
     }

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -21,8 +21,9 @@ pub use crate::metadata::CollectionKind;
 use crate::metadata::{FileInfo, GeneMetadata};
 
 /// Computed descriptor properties that mirror `FileInfo` fields; user
-/// properties cannot shadow them.
-const RESERVED_PROPERTIES: [&str; 6] = [
+/// properties cannot shadow them (enforced both in `register_table` and on
+/// the direct `save_*_with` write paths).
+pub(crate) const RESERVED_PROPERTIES: [&str; 6] = [
     "filetype",
     "storage_format",
     "rows",
@@ -199,9 +200,23 @@ impl Catalog for LocalRegistry {
                 .transpose()
         };
         // RFC #81-P1: an explicit `kind` property wins; otherwise the typed
-        // `kind` field is authoritative. Unknown kinds are rejected.
+        // `kind` field is authoritative. Unknown kinds and disagreements
+        // between the two are rejected (review PR #96) — silently picking
+        // one side would let a property contradict the descriptor.
         let kind = match prop("kind") {
-            Some(k) => Some(CollectionKind::parse(&k)?),
+            Some(k) => {
+                let prop_kind = CollectionKind::parse(&k)?;
+                if prop_kind != table.kind {
+                    return Err(StorageError::Invalid(format!(
+                        "kind mismatch for table '{}': typed field is '{}', \
+                         'kind' property is '{}'",
+                        table.name,
+                        table.kind.as_str(),
+                        prop_kind.as_str()
+                    )));
+                }
+                Some(prop_kind)
+            }
             None => Some(table.kind),
         };
         // User properties (everything not computed above) are persisted on

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -1,0 +1,54 @@
+//! Commit serialization for metadata read-modify-write cycles.
+//!
+//! Base concurrency-safety model borrowed from duva's actor design
+//! (<https://github.com/Migorithm/duva>): every storage instance has a single
+//! logical *commit actor*. All metadata mutations (the `load_metadata →
+//! mutate → save_metadata` cycle performed by every `save_*` call) are
+//! serialized through it, so concurrent writers cannot interleave their
+//! cycles and lose each other's registry entries (lost update) — the same
+//! reason duva routes writes through one actor mailbox instead of shared
+//! mutable state.
+//!
+//! Durability of the commit itself remains
+//! [`crate::generations::write_json_atomic`] (tmp + fsync + rename): readers
+//! never observe a half-written commit pointer, and a read after a completed
+//! commit observes its effects (read-your-own-writes). Cross-process
+//! arbitration stays with the transactional-generations work (#93/#81-P5).
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::{Arc, Mutex as StdMutex, OnceLock};
+
+use tokio::sync::Mutex;
+
+use crate::StorageResult;
+
+/// One commit-actor mailbox per metadata path (process-wide).
+fn lock_for(metadata_path: &Path) -> Arc<Mutex<()>> {
+    static LOCKS: OnceLock<StdMutex<HashMap<String, Arc<Mutex<()>>>>> = OnceLock::new();
+    let locks = LOCKS.get_or_init(|| StdMutex::new(HashMap::new()));
+    let key = metadata_path.to_string_lossy().to_string();
+    Arc::clone(
+        locks
+            .lock()
+            .expect("commit lock registry poisoned")
+            .entry(key)
+            .or_insert_with(|| Arc::new(Mutex::new(()))),
+    )
+}
+
+/// Runs `commit` (a full metadata read-modify-write cycle) under the
+/// instance's commit actor: at most one cycle runs at a time for the same
+/// metadata path.
+pub(crate) async fn with_commit_actor<T, F, Fut>(
+    metadata_path: &Path,
+    commit: F,
+) -> StorageResult<T>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = StorageResult<T>>,
+{
+    let mailbox = lock_for(metadata_path);
+    let _guard = mailbox.lock().await;
+    commit().await
+}

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -1,7 +1,8 @@
-//! Commit serialization for metadata read-modify-write cycles.
+//! Commit serialization for metadata read-modify-write cycles and dataset
+//! writes.
 //!
 //! Base concurrency-safety model borrowed from duva's actor design
-//! (<https://github.com/Migorithm/duva>): every storage instance has a single
+//! ([`<https://github.com/Migorithm/duva>`]): every storage instance has a single
 //! logical *commit actor*. All metadata mutations (the `load_metadata →
 //! mutate → save_metadata` cycle performed by every `save_*` call) are
 //! serialized through it, so concurrent writers cannot interleave their
@@ -9,11 +10,18 @@
 //! reason duva routes writes through one actor mailbox instead of shared
 //! mutable state.
 //!
-//! Durability of the commit itself remains
-//! [`crate::generations::write_json_atomic`] (tmp + fsync + rename): readers
-//! never observe a half-written commit pointer, and a read after a completed
-//! commit observes its effects (read-your-own-writes). Cross-process
-//! arbitration stays with the transactional-generations work (#93/#81-P5).
+//! The same mailbox shape extends to Lance dataset writes
+//! ([`with_dataset_write_lock`]): manifest-version allocation and the
+//! commit-point publish of one dataset directory are serialized, so two
+//! concurrent overwrites cannot mint the same `N.manifest` (#95).
+//!
+//! Durability of the commit itself is the tmp + fsync + rename discipline
+//! ([`crate::generations::write_json_atomic`] for metadata, the same
+//! sequence inside the lancefmt writer for data/txn/manifest files):
+//! readers never observe a half-written commit pointer, and a read after a
+//! completed commit observes its effects (read-your-own-writes).
+//! Cross-process arbitration stays with the transactional-generations work
+//! (#93/#81-P5).
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -21,7 +29,7 @@ use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 
 use tokio::sync::Mutex;
 
-use crate::StorageResult;
+use crate::{StorageError, StorageResult};
 
 /// One commit-actor mailbox per metadata path (process-wide).
 fn lock_for(metadata_path: &Path) -> Arc<Mutex<()>> {
@@ -51,4 +59,38 @@ where
     let mailbox = lock_for(metadata_path);
     let _guard = mailbox.lock().await;
     commit().await
+}
+
+/// One dataset-write mailbox per dataset directory (process-wide, sync —
+/// `write_dataset` runs on the blocking pool).
+///
+/// Serializes manifest-version allocation (`latest_manifest_version` →
+/// `+1`) against concurrent overwrites of the same dataset (#95): without
+/// it two writers could mint the same `N.manifest` and one overwrite would
+/// be silently lost.
+fn dataset_lock_for(dataset_dir: &Path) -> Arc<StdMutex<()>> {
+    static LOCKS: OnceLock<StdMutex<HashMap<String, Arc<StdMutex<()>>>>> = OnceLock::new();
+    let locks = LOCKS.get_or_init(|| StdMutex::new(HashMap::new()));
+    let key = dataset_dir.to_string_lossy().to_string();
+    Arc::clone(
+        locks
+            .lock()
+            .expect("dataset lock registry poisoned")
+            .entry(key)
+            .or_insert_with(|| Arc::new(StdMutex::new(()))),
+    )
+}
+
+/// Runs `write` under the dataset's write mailbox. `write` must be a
+/// non-async closure: the whole dataset write — version allocation through
+/// commit-point publish — happens under the lock.
+pub(crate) fn with_dataset_write_lock<T>(
+    dataset_dir: &Path,
+    write: impl FnOnce() -> StorageResult<T>,
+) -> StorageResult<T> {
+    let mailbox = dataset_lock_for(dataset_dir);
+    let _guard = mailbox
+        .lock()
+        .map_err(|_| StorageError::InvalidState("dataset write lock poisoned".into()))?;
+    write()
 }

--- a/src/generations.rs
+++ b/src/generations.rs
@@ -39,6 +39,10 @@ pub fn generation_name(logical: &str, generation: u64) -> String {
 
 /// Parse the generation number out of a gen-qualified instance name.
 /// Returns `None` for plain logical names or malformed suffixes.
+///
+/// Note (#95): digit suffixes above `u64::MAX` parse to `None` here; the
+/// scanners combine this with a `unwrap_or(u64::MAX)` fallback so such names
+/// sort last consistently instead of crashing discovery.
 pub fn parse_generation(name: &str) -> Option<u64> {
     let pos = name.rfind(GENERATION_SEP)?;
     let suffix = &name[pos + GENERATION_SEP.len()..];
@@ -104,6 +108,13 @@ pub async fn list_artifact_generations(base: &Path, logical: &str) -> StorageRes
 /// metadata commit pointer. Prefix matching is exact on
 /// `{logical}__g{gen}_`, so sibling datasets (`ds` vs `ds2`) are untouched.
 /// Safe to call on orphaned generations (no metadata) and on missing ones.
+///
+/// Reader isolation (#95): there is no reference counting of in-flight
+/// readers. A sweep that removes a generation a reader is currently scanning
+/// will surface as an `Io` error mid-read; callers must serialize sweeps
+/// against reads (e.g. via the commit actor) or treat absence as
+/// "generation retired". Readers that need stable views should open by
+/// generation number and re-resolve on failure.
 pub async fn delete_generation(base: &Path, logical: &str, generation: u64) -> StorageResult<()> {
     let prefix = format!("{logical}{GENERATION_SEP}{generation}_");
     let mut rd = tokio::fs::read_dir(base)
@@ -131,16 +142,20 @@ pub async fn delete_generation(base: &Path, logical: &str, generation: u64) -> S
     Ok(())
 }
 
-/// Atomic JSON publish: write to `{path}.tmp`, fsync, rename over `path`.
+/// Atomic JSON publish: write to a unique `{path}.tmp`, fsync, rename over
+/// `path`.
 ///
 /// The rename is the single commit point (POSIX-atomic within a directory):
 /// concurrent readers observe either the previous file or the complete new
 /// one, never a truncated write. This is the ONLY sanctioned way to publish
-/// a metadata file.
+/// a metadata file. The tmp name is uuid-unique (#95) so concurrent
+/// publishers of the same path cannot corrupt each other's staging file;
+/// the last rename wins, which makes last-writer-wins explicit instead of
+/// interleaved.
 pub fn write_json_atomic(path: &Path, contents: &str) -> StorageResult<()> {
     use std::io::Write;
 
-    let tmp = path.with_extension("json.tmp");
+    let tmp = path.with_extension(format!("json.tmp.{}", uuid::Uuid::new_v4().simple()));
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| StorageError::Io(e.to_string()))?;
     }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,0 +1,180 @@
+//! First-class graph storage types (RFC #81-P3).
+//!
+//! The canonical on-disk layout is an edge-list Lance dataset:
+//! `src: UInt32|UInt64`, `dst: UInt32|UInt64` and an optional
+//! `weight: Float32` column (all non-null). Node-id width is schema-chosen
+//! (`u32` default, `u64` opt-in) and declares the storage-type limit
+//! explicitly rather than truncating (consistent with #51). `CsMat` CSR
+//! conversion stays at the API boundary ([`StoredGraph::to_csr`]); sprs
+//! never reaches the format layer.
+
+use std::collections::BTreeMap;
+
+use sprs::{CsMat, TriMat};
+
+use crate::{StorageError, StorageResult};
+
+/// Node-id storage width of a graph collection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NodeIdWidth {
+    /// `UInt32` ids (default); caps the graph at ~4.29 billion nodes.
+    U32,
+    /// `UInt64` ids (opt-in via schema).
+    U64,
+}
+
+impl NodeIdWidth {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            NodeIdWidth::U32 => "u32",
+            NodeIdWidth::U64 => "u64",
+        }
+    }
+
+    pub fn parse(s: &str) -> StorageResult<Self> {
+        match s {
+            "u32" => Ok(NodeIdWidth::U32),
+            "u64" => Ok(NodeIdWidth::U64),
+            other => Err(StorageError::Invalid(format!(
+                "unknown node-id width '{other}' (expected u32 or u64)"
+            ))),
+        }
+    }
+
+    /// The `DataType` used for `src`/`dst` columns at this width.
+    pub(crate) const fn data_type(self) -> arrow::datatypes::DataType {
+        match self {
+            NodeIdWidth::U32 => arrow::datatypes::DataType::UInt32,
+            NodeIdWidth::U64 => arrow::datatypes::DataType::UInt64,
+        }
+    }
+}
+
+/// A directed edge with an optional weight (RFC #81-P3).
+///
+/// `weight` is `f32`, per the RFC decision that graph weights live in
+/// `[-1.0, 1.0]`. A collection is either fully weighted or topology-only;
+/// mixed edges are rejected.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct GraphEdge {
+    pub src: u64,
+    pub dst: u64,
+    pub weight: Option<f32>,
+}
+
+impl GraphEdge {
+    pub fn weighted(src: u64, dst: u64, weight: f32) -> Self {
+        Self {
+            src,
+            dst,
+            weight: Some(weight),
+        }
+    }
+
+    pub fn unweighted(src: u64, dst: u64) -> Self {
+        Self {
+            src,
+            dst,
+            weight: None,
+        }
+    }
+}
+
+/// Options for [`crate::traits::backend::StorageBackend::save_graph_with`].
+#[derive(Debug, Clone)]
+pub struct GraphWriteOptions {
+    /// Storage width for node ids (default `U32`); ids above the limit
+    /// surface [`StorageError::Overflow`] instead of being truncated.
+    pub node_id_width: NodeIdWidth,
+    /// Explicit node count (e.g. to keep isolated vertices). Must be at
+    /// least `max(src, dst) + 1` over all edges; defaults to exactly that.
+    pub num_nodes: Option<u64>,
+    /// User properties stored on the collection (registry level) and
+    /// stamped into the dataset schema metadata (dataset level).
+    pub properties: BTreeMap<String, String>,
+}
+
+impl Default for GraphWriteOptions {
+    fn default() -> Self {
+        Self {
+            node_id_width: NodeIdWidth::U32,
+            num_nodes: None,
+            properties: BTreeMap::new(),
+        }
+    }
+}
+
+impl GraphWriteOptions {
+    pub fn with_width(node_id_width: NodeIdWidth) -> Self {
+        Self {
+            node_id_width,
+            ..Default::default()
+        }
+    }
+}
+
+/// A graph collection loaded back from storage (RFC #81-P3).
+#[derive(Debug, Clone, PartialEq)]
+pub struct StoredGraph {
+    /// Edges in stored order; `weight` is `None` for topology-only
+    /// collections.
+    pub edges: Vec<GraphEdge>,
+    /// Storage width used for node ids.
+    pub node_id_width: NodeIdWidth,
+    /// Node count (from the dataset metadata; isolated vertices included).
+    pub num_nodes: u64,
+    /// Whether the edge list carries weights.
+    pub weighted: bool,
+}
+
+impl StoredGraph {
+    /// Converts the edge list to a CSR matrix at the API boundary.
+    ///
+    /// Topology-only graphs get weight `1.0` (unweighted convention); the
+    /// result is `CsMat<f64>` with weights upcast from `f32` losslessly.
+    pub fn to_csr(&self) -> StorageResult<CsMat<f64>> {
+        let n = self.num_nodes;
+        if n > usize::MAX as u64 {
+            return Err(StorageError::Overflow(format!(
+                "node count {n} exceeds the addressable size"
+            )));
+        }
+        let n = n as usize;
+        let mut trimat = TriMat::new((n, n));
+        trimat.reserve(nnz_hint(self.edges.len()));
+        for edge in &self.edges {
+            let (src, dst) = (edge.src as usize, edge.dst as usize);
+            if src >= n || dst >= n {
+                return Err(StorageError::Invalid(format!(
+                    "edge ({}, {}) out of bounds for {}-node graph",
+                    edge.src, edge.dst, n
+                )));
+            }
+            let weight = match edge.weight {
+                Some(w) => w as f64,
+                None => 1.0,
+            };
+            trimat.add_triplet(src, dst, weight);
+        }
+        let csr = trimat.to_csr();
+        if csr.rows() != n || csr.cols() != n {
+            return Err(StorageError::Invalid(format!(
+                "dimension mismatch after CSR conversion: expected {n}x{n}, got {}x{}",
+                csr.rows(),
+                csr.cols()
+            )));
+        }
+        Ok(csr)
+    }
+}
+
+fn nnz_hint(len: usize) -> usize {
+    // TriMat::reserve clamps to capacity; keep the hint modest.
+    len.min(1 << 20)
+}
+
+/// Dataset-level schema-metadata keys stamped by the `save_graph` /
+/// `save_vectors` writers (RFC #81-P1: dataset-level kinds alongside
+/// registry-level kinds). User properties may not shadow these.
+pub(crate) const RESERVED_METADATA_KEYS: [&str; 4] =
+    ["kind", "node_id_width", "weighted", "num_nodes"];

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -141,7 +141,7 @@ impl StoredGraph {
         }
         let n = n as usize;
         let mut trimat = TriMat::new((n, n));
-        trimat.reserve(nnz_hint(self.edges.len()));
+        trimat.reserve(self.edges.len());
         for edge in &self.edges {
             let (src, dst) = (edge.src as usize, edge.dst as usize);
             if src >= n || dst >= n {
@@ -166,11 +166,6 @@ impl StoredGraph {
         }
         Ok(csr)
     }
-}
-
-fn nnz_hint(len: usize) -> usize {
-    // TriMat::reserve clamps to capacity; keep the hint modest.
-    len.min(1 << 20)
 }
 
 /// Dataset-level schema-metadata keys stamped by the `save_graph` /

--- a/src/lance_storage_graph.rs
+++ b/src/lance_storage_graph.rs
@@ -4,20 +4,25 @@
 //! - All I/O is async, no internal `block_on` or runtime creation.
 //! - Callers (CLI, tests, services) are responsible for providing a Tokio runtime.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
-use arrow::array::{Array as ArrowArray, Float64Array, UInt32Array};
-use arrow::datatypes::{DataType, Float64Type, Int64Type, UInt32Type};
+use arrow::array::{
+    Array as ArrowArray, ArrayRef, Float32Array, Float64Array, UInt32Array, UInt64Array,
+};
+use arrow::datatypes::{DataType, Field, Float64Type, Int64Type, Schema, UInt32Type};
 use arrow::record_batch::RecordBatch;
 use log::{debug, info};
 use smartcore::linalg::basic::arrays::Array;
 use smartcore::linalg::basic::matrix::DenseMatrix;
 use sprs::CsMat;
 
+use crate::graph::{GraphEdge, GraphWriteOptions, NodeIdWidth, StoredGraph};
 use crate::metadata::FileInfo;
 use crate::metadata::GeneMetadata;
 use crate::traits::backend::StorageBackend;
-use crate::traits::lance::LanceStorage;
+use crate::traits::lance::{LanceStorage, validate_vector_space_schema, with_collection_metadata};
 use crate::{StorageError, StorageResult};
 
 /// Checked `usize -> u32` conversion.
@@ -210,18 +215,24 @@ impl StorageBackend for LanceStorageGraph {
             // Write to Lance
             let uri = Self::path_to_uri(&path)?;
             self.write_lance_batch_async(uri, batch).await?;
-            let mut md = self.load_metadata().await?;
-            md = md.add_file(
-                key,
-                FileInfo::new(
-                    format!("{}_{}.lance", self.get_name(), key),
-                    "dense",
-                    matrix.shape(),
-                    None,
-                    None,
-                )?,
-            );
-            self.save_metadata(&md).await?;
+            // Commit the registry entry through the instance's commit actor:
+            // concurrent save_* calls serialize their read-modify-write
+            // cycles instead of losing updates (duva actor model).
+            crate::commit::with_commit_actor(&self.metadata_path(), || async {
+                let mut md = self.load_metadata().await?;
+                md = md.add_file(
+                    key,
+                    FileInfo::new(
+                        format!("{}_{}.lance", self.get_name(), key),
+                        "dense",
+                        matrix.shape(),
+                        None,
+                        None,
+                    )?,
+                );
+                self.save_metadata(&md).await
+            })
+            .await?;
             info!("Dense {} matrix saved successfully", key);
         }
         Ok(())
@@ -465,18 +476,21 @@ impl StorageBackend for LanceStorageGraph {
 
         let filetype = FileInfo::which_filetype(key)?;
         {
-            let mut metadata = self.load_metadata().await?;
-            metadata = metadata.add_file(
-                key,
-                FileInfo::new(
-                    format!("{}_{}.lance", self.get_name(), key),
-                    filetype.as_str(),
-                    (matrix.rows(), matrix.cols()),
-                    Some(matrix.nnz()),
-                    None,
-                )?,
-            );
-            self.save_metadata(&metadata).await?;
+            crate::commit::with_commit_actor(&self.metadata_path(), || async {
+                let mut metadata = self.load_metadata().await?;
+                metadata = metadata.add_file(
+                    key,
+                    FileInfo::new(
+                        format!("{}_{}.lance", self.get_name(), key),
+                        filetype.as_str(),
+                        (matrix.rows(), matrix.cols()),
+                        Some(matrix.nnz()),
+                        None,
+                    )?,
+                );
+                self.save_metadata(&metadata).await
+            })
+            .await?;
 
             let batch = self.to_sparse_record_batch(matrix)?;
             let uri = Self::path_to_uri(&path)?;
@@ -781,18 +795,21 @@ impl StorageBackend for LanceStorageGraph {
 
         let batch = self.to_dense_record_batch(subcentroids)?;
         {
-            let mut metadata = self.load_metadata().await?;
-            metadata = metadata.add_file(
-                key,
-                FileInfo::new(
-                    format!("{}_{}.lance", self.get_name(), key),
-                    "vector",
-                    subcentroids.shape(),
-                    None,
-                    None,
-                )?,
-            );
-            self.save_metadata(&metadata).await?;
+            crate::commit::with_commit_actor(&self.metadata_path(), || async {
+                let mut metadata = self.load_metadata().await?;
+                metadata = metadata.add_file(
+                    key,
+                    FileInfo::new(
+                        format!("{}_{}.lance", self.get_name(), key),
+                        "vector",
+                        subcentroids.shape(),
+                        None,
+                        None,
+                    )?,
+                );
+                self.save_metadata(&metadata).await
+            })
+            .await?;
 
             let uri = Self::path_to_uri(&path)?;
             self.write_lance_batch_async(uri, batch).await?;
@@ -901,5 +918,311 @@ impl StorageBackend for LanceStorageGraph {
             .collect();
         info!("Loaded {} cluster assignments", assignments.len());
         Ok(assignments)
+    }
+
+    // =========
+    // NAMED COLLECTIONS (RFC #81)
+    // =========
+
+    async fn save_vectors_with(
+        &self,
+        name: &str,
+        batch: &RecordBatch,
+        properties: &BTreeMap<String, String>,
+        md_path: &Path,
+    ) -> StorageResult<()> {
+        self.validate_initialized(md_path)?;
+        if batch.num_rows() == 0 {
+            return Err(StorageError::Invalid(
+                "empty vector-space collections are not supported".into(),
+            ));
+        }
+        let (dim, _item_type) = validate_vector_space_schema(batch.schema().as_ref())?;
+        let batch = with_collection_metadata(batch, "vector-space", &[], properties)?;
+
+        let path = self.file_path(name);
+        info!(
+            "Saving vector-space collection '{}' ({} rows, vector dim {}) at {:?}",
+            name,
+            batch.num_rows(),
+            dim,
+            path
+        );
+        let uri = Self::path_to_uri(&path)?;
+        self.write_lance_batch_async(uri, batch.clone()).await?;
+
+        crate::commit::with_commit_actor(&self.metadata_path(), || async {
+            let mut md = self.load_metadata().await?;
+            let mut info = FileInfo::new(
+                format!("{}_{}.lance", self.get_name(), name),
+                "vectors",
+                (batch.num_rows(), dim as usize),
+                None,
+                None,
+            )?;
+            info.properties = properties.clone();
+            md = md.add_file(name, info);
+            self.save_metadata(&md).await
+        })
+        .await?;
+        info!("Vector-space collection '{}' saved successfully", name);
+        Ok(())
+    }
+
+    async fn load_vectors(&self, name: &str) -> StorageResult<RecordBatch> {
+        let path = self.file_path(name);
+        info!("Loading vector-space collection '{}' from {:?}", name, path);
+        let uri = Self::path_to_uri(&path)?;
+        let batch = self.read_lance_all_batches_async(uri).await?;
+        validate_vector_space_schema(batch.schema().as_ref())?;
+        info!(
+            "Loaded vector-space collection '{}': {} rows",
+            name,
+            batch.num_rows()
+        );
+        Ok(batch)
+    }
+
+    async fn save_graph_with(
+        &self,
+        name: &str,
+        edges: &[GraphEdge],
+        options: &GraphWriteOptions,
+        md_path: &Path,
+    ) -> StorageResult<()> {
+        self.validate_initialized(md_path)?;
+        if edges.is_empty() {
+            return Err(StorageError::Invalid(
+                "empty graph collections are not supported".into(),
+            ));
+        }
+        // A collection is fully weighted or topology-only; mixed edges are
+        // rejected instead of being coerced.
+        let weighted = edges[0].weight.is_some();
+        if edges.iter().any(|e| e.weight.is_some() != weighted) {
+            return Err(StorageError::Invalid(
+                "graph collection must be either fully weighted or topology-only; \
+                 mixed edges are rejected"
+                    .into(),
+            ));
+        }
+        // The schema declares the storage-type limit; ids above it surface
+        // Overflow instead of being silently truncated (consistent with #51).
+        let max_id = edges.iter().map(|e| e.src.max(e.dst)).max().unwrap_or(0);
+        let width = options.node_id_width;
+        if width == NodeIdWidth::U32 && max_id > u32::MAX as u64 {
+            return Err(StorageError::Overflow(format!(
+                "node id {max_id} exceeds u32::MAX; save with NodeIdWidth::U64"
+            )));
+        }
+        let num_nodes = match options.num_nodes {
+            Some(n) if n < max_id + 1 => {
+                return Err(StorageError::Invalid(format!(
+                    "num_nodes {n} is smaller than the highest node id + 1 ({})",
+                    max_id + 1
+                )));
+            }
+            Some(n) => n,
+            None => max_id + 1,
+        };
+        let num_nodes_usize = usize::try_from(num_nodes)
+            .map_err(|_| StorageError::Overflow(format!("node count {num_nodes} exceeds usize")))?;
+
+        let (src, dst): (ArrayRef, ArrayRef) = match width {
+            NodeIdWidth::U32 => (
+                Arc::new(UInt32Array::from_iter_values(
+                    edges.iter().map(|e| e.src as u32),
+                )),
+                Arc::new(UInt32Array::from_iter_values(
+                    edges.iter().map(|e| e.dst as u32),
+                )),
+            ),
+            NodeIdWidth::U64 => (
+                Arc::new(UInt64Array::from_iter_values(edges.iter().map(|e| e.src))),
+                Arc::new(UInt64Array::from_iter_values(edges.iter().map(|e| e.dst))),
+            ),
+        };
+        let mut fields = vec![
+            Field::new("src", width.data_type(), false),
+            Field::new("dst", width.data_type(), false),
+        ];
+        let mut columns: Vec<ArrayRef> = vec![src, dst];
+        if weighted {
+            fields.push(Field::new("weight", DataType::Float32, false));
+            columns.push(Arc::new(Float32Array::from_iter_values(
+                edges.iter().map(|e| e.weight.unwrap()),
+            )));
+        }
+        let batch = RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
+            .map_err(|e| StorageError::Lance(e.to_string()))?;
+        // Dataset-level kind + graph layout facts (RFC #81-P1/P3).
+        let batch = with_collection_metadata(
+            &batch,
+            "graph",
+            &[
+                ("node_id_width", width.as_str().to_string()),
+                ("weighted", weighted.to_string()),
+                ("num_nodes", num_nodes.to_string()),
+            ],
+            &options.properties,
+        )?;
+
+        let path = self.file_path(name);
+        info!(
+            "Saving graph collection '{}' ({} edges, {} nodes, width {:?}, weighted {}) at {:?}",
+            name,
+            edges.len(),
+            num_nodes,
+            width,
+            weighted,
+            path
+        );
+        let uri = Self::path_to_uri(&path)?;
+        self.write_lance_batch_async(uri, batch).await?;
+
+        crate::commit::with_commit_actor(&self.metadata_path(), || async {
+            let mut md = self.load_metadata().await?;
+            let mut info = FileInfo::new(
+                format!("{}_{}.lance", self.get_name(), name),
+                "graph",
+                (num_nodes_usize, num_nodes_usize),
+                Some(edges.len()),
+                None,
+            )?;
+            info.properties = options.properties.clone();
+            info.properties
+                .insert("node_id_width".to_string(), width.as_str().to_string());
+            info.properties
+                .insert("weighted".to_string(), weighted.to_string());
+            info.properties
+                .insert("num_nodes".to_string(), num_nodes.to_string());
+            md = md.add_file(name, info);
+            self.save_metadata(&md).await
+        })
+        .await?;
+        info!("Graph collection '{}' saved successfully", name);
+        Ok(())
+    }
+
+    async fn load_graph(&self, name: &str) -> StorageResult<StoredGraph> {
+        let path = self.file_path(name);
+        info!("Loading graph collection '{}' from {:?}", name, path);
+        let uri = Self::path_to_uri(&path)?;
+        let batch = self.read_lance_all_batches_async(uri).await?;
+
+        let schema = batch.schema();
+        let n_cols = schema.fields().len();
+        if !(2..=3).contains(&n_cols) {
+            return Err(StorageError::Invalid(format!(
+                "graph edge-list schema expects src/dst (and optionally weight) columns, \
+                 found {n_cols}"
+            )));
+        }
+        let width = match (schema.field(0).data_type(), schema.field(1).data_type()) {
+            (DataType::UInt32, DataType::UInt32) => NodeIdWidth::U32,
+            (DataType::UInt64, DataType::UInt64) => NodeIdWidth::U64,
+            (s, d) => {
+                return Err(StorageError::Invalid(format!(
+                    "graph src/dst columns must share width UInt32|UInt64, found {s:?}/{d:?}"
+                )));
+            }
+        };
+        let weighted = n_cols == 3;
+        if weighted && schema.field(2).data_type() != &DataType::Float32 {
+            return Err(StorageError::Invalid(format!(
+                "graph weight column must be Float32, found {:?}",
+                schema.field(2).data_type()
+            )));
+        }
+
+        let ids = |col: usize, what: &'static str| -> StorageResult<Vec<u64>> {
+            let arr = batch.column(col);
+            if arr.null_count() != 0 {
+                return Err(StorageError::Invalid(format!(
+                    "graph '{what}' column contains nulls"
+                )));
+            }
+            match width {
+                NodeIdWidth::U32 => {
+                    let a = arr.as_any().downcast_ref::<UInt32Array>().ok_or_else(|| {
+                        StorageError::Invalid(format!("graph '{what}' column type mismatch"))
+                    })?;
+                    Ok((0..a.len()).map(|i| a.value(i) as u64).collect())
+                }
+                NodeIdWidth::U64 => {
+                    let a = arr.as_any().downcast_ref::<UInt64Array>().ok_or_else(|| {
+                        StorageError::Invalid(format!("graph '{what}' column type mismatch"))
+                    })?;
+                    Ok((0..a.len()).map(|i| a.value(i)).collect())
+                }
+            }
+        };
+        let src = ids(0, "src")?;
+        let dst = ids(1, "dst")?;
+        let weights: Option<Vec<f32>> = if weighted {
+            let w = batch.column(2);
+            if w.null_count() != 0 {
+                return Err(StorageError::Invalid(
+                    "graph 'weight' column contains nulls".into(),
+                ));
+            }
+            let a = w.as_any().downcast_ref::<Float32Array>().ok_or_else(|| {
+                StorageError::Invalid("graph 'weight' column type mismatch".into())
+            })?;
+            Some((0..a.len()).map(|i| a.value(i)).collect())
+        } else {
+            None
+        };
+
+        // Node count: dataset-level metadata if present (isolated vertices
+        // included), otherwise the highest id + 1.
+        let max_id = src
+            .iter()
+            .zip(dst.iter())
+            .map(|(s, d)| (*s).max(*d))
+            .max()
+            .unwrap_or(0);
+        let num_nodes = schema
+            .metadata()
+            .get("num_nodes")
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(max_id + 1);
+        let edges: Vec<GraphEdge> = match &weights {
+            Some(weights) => src
+                .iter()
+                .zip(dst.iter())
+                .zip(weights.iter())
+                .map(|((s, d), w)| GraphEdge::weighted(*s, *d, *w))
+                .collect(),
+            None => src
+                .iter()
+                .zip(dst.iter())
+                .map(|(s, d)| GraphEdge::unweighted(*s, *d))
+                .collect(),
+        };
+        if let Some(e) = edges
+            .iter()
+            .find(|e| e.src >= num_nodes || e.dst >= num_nodes)
+        {
+            return Err(StorageError::Invalid(format!(
+                "edge ({}, {}) out of bounds for {}-node graph",
+                e.src, e.dst, num_nodes
+            )));
+        }
+
+        info!(
+            "Loaded graph collection '{}': {} edges, {} nodes, width {:?}, weighted {}",
+            name,
+            edges.len(),
+            num_nodes,
+            width,
+            weighted
+        );
+        Ok(StoredGraph {
+            edges,
+            node_id_width: width,
+            num_nodes,
+            weighted,
+        })
     }
 }

--- a/src/lance_storage_graph.rs
+++ b/src/lance_storage_graph.rs
@@ -22,7 +22,10 @@ use crate::graph::{GraphEdge, GraphWriteOptions, NodeIdWidth, StoredGraph};
 use crate::metadata::FileInfo;
 use crate::metadata::GeneMetadata;
 use crate::traits::backend::StorageBackend;
-use crate::traits::lance::{LanceStorage, validate_vector_space_schema, with_collection_metadata};
+use crate::traits::lance::{
+    LanceStorage, reject_reserved_user_properties, validate_vector_space_schema,
+    with_collection_metadata,
+};
 use crate::{StorageError, StorageResult};
 
 /// Checked `usize -> u32` conversion.
@@ -931,6 +934,7 @@ impl StorageBackend for LanceStorageGraph {
         properties: &BTreeMap<String, String>,
         md_path: &Path,
     ) -> StorageResult<()> {
+        reject_reserved_user_properties(properties)?;
         self.validate_initialized(md_path)?;
         if batch.num_rows() == 0 {
             return Err(StorageError::Invalid(
@@ -990,6 +994,7 @@ impl StorageBackend for LanceStorageGraph {
         options: &GraphWriteOptions,
         md_path: &Path,
     ) -> StorageResult<()> {
+        reject_reserved_user_properties(&options.properties)?;
         self.validate_initialized(md_path)?;
         if edges.is_empty() {
             return Err(StorageError::Invalid(

--- a/src/lancefmt/reader.rs
+++ b/src/lancefmt/reader.rs
@@ -9,7 +9,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use arrow::array::{ArrayRef, FixedSizeListArray, Float64Array, UInt32Array};
+use arrow::array::{ArrayRef, FixedSizeListArray, Float32Array, Float64Array, UInt32Array};
 use arrow::datatypes::{DataType, Field as ArrowField, Schema as ArrowSchema};
 use arrow::record_batch::RecordBatch;
 use prost::Message;
@@ -113,7 +113,10 @@ fn decode_direct_any(encoding: &Option<lfv2::Encoding>) -> StorageResult<Vec<u8>
 /// One decoded chunk: `values` holds the logical values of the chunk.
 enum ChunkValues {
     F64(Vec<f64>),
+    F32(Vec<f32>),
+    U8(Vec<u8>),
     U32(Vec<u32>),
+    U64(Vec<u64>),
     I64(Vec<i64>),
 }
 
@@ -122,15 +125,26 @@ enum ChunkValues {
 #[derive(Clone, Copy, PartialEq, Debug)]
 enum Leaf {
     F64,
+    F32,
+    U8,
     U32,
+    U64,
     I64,
 }
 
 fn leaf_of(dt: &DataType) -> StorageResult<Leaf> {
     match dt {
-        DataType::Float64 | DataType::FixedSizeList(_, _) => Ok(Leaf::F64),
+        DataType::Float64 => Ok(Leaf::F64),
+        DataType::Float32 => Ok(Leaf::F32),
+        DataType::UInt8 => Ok(Leaf::U8),
         DataType::UInt32 => Ok(Leaf::U32),
+        DataType::UInt64 => Ok(Leaf::U64),
         DataType::Int64 => Ok(Leaf::I64),
+        DataType::FixedSizeList(child, _) => match child.data_type() {
+            DataType::Float64 => Ok(Leaf::F64),
+            DataType::Float32 => Ok(Leaf::F32),
+            other => Err(unsupported(&format!("fsl item type {other:?}"))),
+        },
         other => Err(unsupported(&format!("column type {other:?}"))),
     }
 }
@@ -152,6 +166,15 @@ fn decode_chunk(
                     .collect();
                 Ok(ChunkValues::F64(values))
             }
+            (Leaf::F32, 32) => {
+                let values = buffer
+                    .as_chunks::<4>()
+                    .0
+                    .iter()
+                    .map(|b| f32::from_le_bytes(*b))
+                    .collect();
+                Ok(ChunkValues::F32(values))
+            }
             (Leaf::I64, 64) => {
                 let values = buffer
                     .as_chunks::<8>()
@@ -160,6 +183,15 @@ fn decode_chunk(
                     .map(|b| i64::from_le_bytes(*b))
                     .collect();
                 Ok(ChunkValues::I64(values))
+            }
+            (Leaf::U64, 64) => {
+                let values = buffer
+                    .as_chunks::<8>()
+                    .0
+                    .iter()
+                    .map(|b| u64::from_le_bytes(*b))
+                    .collect();
+                Ok(ChunkValues::U64(values))
             }
             (Leaf::U32, 32) => {
                 let values = buffer
@@ -170,6 +202,7 @@ fn decode_chunk(
                     .collect();
                 Ok(ChunkValues::U32(values))
             }
+            (Leaf::U8, 8) => Ok(ChunkValues::U8(buffer.to_vec())),
             (leaf, bits) => Err(unsupported(&format!(
                 "Flat bits_per_value={bits} for leaf {leaf:?}"
             ))),
@@ -253,11 +286,127 @@ fn decode_chunk(
                     out[..n].iter().map(|v| *v as i64).collect(),
                 ))
             }
+            (Leaf::U64, 64) => {
+                if buffer.len() < 4 {
+                    return Err(StorageError::Invalid("bitpacked chunk too small".into()));
+                }
+                let width = u32::from_le_bytes(buffer[0..4].try_into().unwrap()) as usize;
+                let packed = &buffer[4..];
+                if !packed.len().is_multiple_of(8) {
+                    return Err(StorageError::Invalid(
+                        "bitpacked chunk not word-aligned".into(),
+                    ));
+                }
+                let words: Vec<u64> = packed
+                    .as_chunks::<8>()
+                    .0
+                    .iter()
+                    .map(|b| u64::from_le_bytes(*b))
+                    .collect();
+                let block_words = (1024usize * width).div_ceil(64);
+                if words.len() < block_words {
+                    return Err(StorageError::Invalid(
+                        "bitpacked chunk shorter than one FL block".into(),
+                    ));
+                }
+                let mut out = vec![0u64; 1024];
+                // SAFETY: `out` has exactly the FL block size for u64 and
+                // `words` holds one full block of packed words.
+                unsafe {
+                    use lance_bitpacking::BitPacking;
+                    <u64 as BitPacking>::unchecked_unpack(width, &words[..block_words], &mut out);
+                }
+                let n = values_in_chunk as usize;
+                if n > 1024 {
+                    return Err(StorageError::Invalid(
+                        "bitpacked chunk claims more than 1024 values".into(),
+                    ));
+                }
+                Ok(ChunkValues::U64(out[..n].to_vec()))
+            }
+            (Leaf::U8, 8) => {
+                if buffer.len() < 4 {
+                    return Err(StorageError::Invalid("bitpacked chunk too small".into()));
+                }
+                let width = u32::from_le_bytes(buffer[0..4].try_into().unwrap()) as usize;
+                if width > 8 {
+                    return Err(StorageError::Invalid(format!(
+                        "u8 bitpacked width {width} exceeds 8 bits"
+                    )));
+                }
+                let packed = &buffer[4..];
+                let block_bytes = (1024usize * width).div_ceil(8);
+                if packed.len() < block_bytes {
+                    return Err(StorageError::Invalid(
+                        "bitpacked chunk shorter than one FL block".into(),
+                    ));
+                }
+                let mut out = vec![0u8; 1024];
+                // SAFETY: `out` has exactly the FL block size for u8 and
+                // `packed` starts with one full block of packed bytes.
+                unsafe {
+                    use lance_bitpacking::BitPacking;
+                    <u8 as BitPacking>::unchecked_unpack(width, &packed[..block_bytes], &mut out);
+                }
+                let n = values_in_chunk as usize;
+                if n > 1024 {
+                    return Err(StorageError::Invalid(
+                        "bitpacked chunk claims more than 1024 values".into(),
+                    ));
+                }
+                Ok(ChunkValues::U8(out[..n].to_vec()))
+            }
             (leaf, bits) => Err(unsupported(&format!(
                 "InlineBitpacking uncompressed_bits_per_value={bits} for leaf {leaf:?}"
             ))),
         },
         other => Err(unsupported(&format!("value compression {other:?}"))),
+    }
+}
+
+/// Per-leaf decoded value accumulators for one page.
+#[derive(Default)]
+struct ColumnValues {
+    f64: Vec<f64>,
+    f32: Vec<f32>,
+    u8: Vec<u8>,
+    u32: Vec<u32>,
+    u64: Vec<u64>,
+    i64: Vec<i64>,
+}
+
+impl ColumnValues {
+    fn append(&mut self, values: ChunkValues) {
+        match values {
+            ChunkValues::F64(mut v) => self.f64.append(&mut v),
+            ChunkValues::F32(mut v) => self.f32.append(&mut v),
+            ChunkValues::U8(mut v) => self.u8.append(&mut v),
+            ChunkValues::U32(mut v) => self.u32.append(&mut v),
+            ChunkValues::U64(mut v) => self.u64.append(&mut v),
+            ChunkValues::I64(mut v) => self.i64.append(&mut v),
+        }
+    }
+
+    /// Rejects chunks decoded into any leaf type other than the expected
+    /// ones for the column (guards against encoding/schema confusion).
+    fn keep_only(&self, keep: &[&str]) -> StorageResult<()> {
+        let checks: [(&str, usize); 6] = [
+            ("f64", self.f64.len()),
+            ("f32", self.f32.len()),
+            ("u8", self.u8.len()),
+            ("u32", self.u32.len()),
+            ("u64", self.u64.len()),
+            ("i64", self.i64.len()),
+        ];
+        for (name, len) in checks {
+            if len > 0 && !keep.contains(&name) {
+                return Err(StorageError::Invalid(format!(
+                    "{name} values in {} column",
+                    keep.join("|")
+                )));
+            }
+        }
+        Ok(())
     }
 }
 
@@ -304,9 +453,7 @@ fn decode_page(
     // Walk chunks: metadata is one u16 per chunk; the data buffer holds the
     // chunks back to back.
     let leaf = leaf_of(expected_type)?;
-    let mut f64_out: Vec<f64> = Vec::new();
-    let mut u32_out: Vec<u32> = Vec::new();
-    let mut i64_out: Vec<i64> = Vec::new();
+    let mut out = ColumnValues::default();
     let mut chunk_data_pos = 0usize;
     let mut vals_so_far: u64 = 0;
     let num_chunks = metadata.len() / 2;
@@ -357,27 +504,44 @@ fn decode_page(
                 else {
                     return Err(unsupported("FixedSizeList without Flat values"));
                 };
-                if flat.bits_per_value != 64 {
-                    return Err(unsupported("FixedSizeList with non-64-bit items"));
+                let expected_bits = match leaf {
+                    Leaf::F64 => 64,
+                    Leaf::F32 => 32,
+                    other => {
+                        return Err(unsupported(&format!("FixedSizeList with {other:?} items")));
+                    }
+                };
+                if flat.bits_per_value != expected_bits {
+                    return Err(unsupported(&format!(
+                        "FixedSizeList with {}-bit items",
+                        flat.bits_per_value
+                    )));
                 }
-                match decode_chunk(
-                    buffer,
-                    &Compression::Flat(*flat),
-                    Leaf::F64,
-                    values_in_chunk,
-                )? {
+                let items_expected = values_in_chunk as usize * fsl.items_per_value as usize;
+                match decode_chunk(buffer, &Compression::Flat(*flat), leaf, values_in_chunk)? {
                     ChunkValues::F64(mut items) => {
-                        let items_expected =
-                            values_in_chunk as usize * fsl.items_per_value as usize;
                         if items.len() != items_expected {
                             return Err(StorageError::DimensionMismatch {
                                 expected: format!("{items_expected} items"),
                                 found: format!("{} items", items.len()),
                             });
                         }
-                        f64_out.append(&mut items);
+                        out.f64.append(&mut items);
                     }
-                    _ => return Err(StorageError::Invalid("fsl decoded as non-f64".into())),
+                    ChunkValues::F32(mut items) => {
+                        if items.len() != items_expected {
+                            return Err(StorageError::DimensionMismatch {
+                                expected: format!("{items_expected} items"),
+                                found: format!("{} items", items.len()),
+                            });
+                        }
+                        out.f32.append(&mut items);
+                    }
+                    _ => {
+                        return Err(StorageError::Invalid(
+                            "fsl decoded as non-float values".into(),
+                        ));
+                    }
                 }
             }
             other => {
@@ -386,11 +550,8 @@ fn decode_page(
                 } else {
                     values_in_chunk
                 };
-                match decode_chunk(buffer, other, leaf, values_in_chunk)? {
-                    ChunkValues::F64(mut v) => f64_out.append(&mut v),
-                    ChunkValues::U32(mut v) => u32_out.append(&mut v),
-                    ChunkValues::I64(mut v) => i64_out.append(&mut v),
-                }
+                let values = decode_chunk(buffer, other, leaf, values_in_chunk)?;
+                out.append(values);
             }
         }
         chunk_data_pos += chunk_bytes;
@@ -403,7 +564,7 @@ fn decode_page(
         )));
     }
 
-    build_array(expected_type, f64_out, u32_out, i64_out, page.length)
+    build_array(expected_type, out, page.length)
 }
 
 fn validate_miniblock(miniblock: &MiniBlockLayout) -> StorageResult<()> {
@@ -428,68 +589,113 @@ fn validate_miniblock(miniblock: &MiniBlockLayout) -> StorageResult<()> {
 
 fn build_array(
     expected_type: &DataType,
-    f64_out: Vec<f64>,
-    u32_out: Vec<u32>,
-    i64_out: Vec<i64>,
+    values: ColumnValues,
     expected_rows: u64,
 ) -> StorageResult<ArrayRef> {
     let arr: ArrayRef = match expected_type {
         DataType::Float64 => {
-            if !u32_out.is_empty() {
-                return Err(StorageError::Invalid("u32 values in f64 column".into()));
-            }
-            if f64_out.len() as u64 != expected_rows {
+            values.keep_only(&["f64"])?;
+            if values.f64.len() as u64 != expected_rows {
                 return Err(StorageError::DimensionMismatch {
                     expected: format!("{expected_rows} values"),
-                    found: format!("{} values", f64_out.len()),
+                    found: format!("{} values", values.f64.len()),
                 });
             }
-            Arc::new(Float64Array::from(f64_out))
+            Arc::new(Float64Array::from(values.f64))
+        }
+        DataType::Float32 => {
+            values.keep_only(&["f32"])?;
+            if values.f32.len() as u64 != expected_rows {
+                return Err(StorageError::DimensionMismatch {
+                    expected: format!("{expected_rows} values"),
+                    found: format!("{} values", values.f32.len()),
+                });
+            }
+            Arc::new(Float32Array::from(values.f32))
+        }
+        DataType::UInt8 => {
+            values.keep_only(&["u8"])?;
+            if values.u8.len() as u64 != expected_rows {
+                return Err(StorageError::DimensionMismatch {
+                    expected: format!("{expected_rows} values"),
+                    found: format!("{} values", values.u8.len()),
+                });
+            }
+            Arc::new(arrow::array::UInt8Array::from(values.u8))
         }
         DataType::UInt32 => {
-            if !f64_out.is_empty() {
-                return Err(StorageError::Invalid("f64 values in u32 column".into()));
-            }
-            if u32_out.len() as u64 != expected_rows {
+            values.keep_only(&["u32"])?;
+            if values.u32.len() as u64 != expected_rows {
                 return Err(StorageError::DimensionMismatch {
                     expected: format!("{expected_rows} values"),
-                    found: format!("{} values", u32_out.len()),
+                    found: format!("{} values", values.u32.len()),
                 });
             }
-            Arc::new(UInt32Array::from(u32_out))
+            Arc::new(UInt32Array::from(values.u32))
+        }
+        DataType::UInt64 => {
+            values.keep_only(&["u64"])?;
+            if values.u64.len() as u64 != expected_rows {
+                return Err(StorageError::DimensionMismatch {
+                    expected: format!("{expected_rows} values"),
+                    found: format!("{} values", values.u64.len()),
+                });
+            }
+            Arc::new(arrow::array::UInt64Array::from(values.u64))
         }
         DataType::Int64 => {
-            if !f64_out.is_empty() || !u32_out.is_empty() {
-                return Err(StorageError::Invalid("non-i64 values in i64 column".into()));
-            }
-            if i64_out.len() as u64 != expected_rows {
+            values.keep_only(&["i64"])?;
+            if values.i64.len() as u64 != expected_rows {
                 return Err(StorageError::DimensionMismatch {
                     expected: format!("{expected_rows} values"),
-                    found: format!("{} values", i64_out.len()),
+                    found: format!("{} values", values.i64.len()),
                 });
             }
-            Arc::new(arrow::array::Int64Array::from(i64_out))
+            Arc::new(arrow::array::Int64Array::from(values.i64))
         }
-        DataType::FixedSizeList(_child, dim) => {
-            if !u32_out.is_empty() {
-                return Err(StorageError::Invalid("u32 values in fsl column".into()));
+        DataType::FixedSizeList(child, dim) => {
+            match child.data_type() {
+                DataType::Float64 => {
+                    values.keep_only(&["f64"])?;
+                    let items_expected = expected_rows * *dim as u64;
+                    if values.f64.len() as u64 != items_expected {
+                        return Err(StorageError::DimensionMismatch {
+                            expected: format!("{items_expected} items"),
+                            found: format!("{} items", values.f64.len()),
+                        });
+                    }
+                    let values = Float64Array::from(values.f64);
+                    // Mirror official-reader behavior: the FSL child field is nullable.
+                    let child = ArrowField::new("item", DataType::Float64, true);
+                    Arc::new(FixedSizeListArray::new(
+                        Arc::new(child),
+                        *dim,
+                        Arc::new(values),
+                        None,
+                    ))
+                }
+                DataType::Float32 => {
+                    values.keep_only(&["f32"])?;
+                    let items_expected = expected_rows * *dim as u64;
+                    if values.f32.len() as u64 != items_expected {
+                        return Err(StorageError::DimensionMismatch {
+                            expected: format!("{items_expected} items"),
+                            found: format!("{} items", values.f32.len()),
+                        });
+                    }
+                    let values = Float32Array::from(values.f32);
+                    let child = ArrowField::new("item", DataType::Float32, true);
+                    Arc::new(FixedSizeListArray::new(
+                        Arc::new(child),
+                        *dim,
+                        Arc::new(values),
+                        None,
+                    ))
+                }
+                other => {
+                    return Err(unsupported(&format!("fsl item type {other:?}")));
+                }
             }
-            let items_expected = expected_rows * *dim as u64;
-            if f64_out.len() as u64 != items_expected {
-                return Err(StorageError::DimensionMismatch {
-                    expected: format!("{items_expected} items"),
-                    found: format!("{} items", f64_out.len()),
-                });
-            }
-            let values = Float64Array::from(f64_out);
-            // Mirror official-reader behavior: the FSL child field is nullable.
-            let child = ArrowField::new("item", DataType::Float64, true);
-            Arc::new(FixedSizeListArray::new(
-                Arc::new(child),
-                *dim,
-                Arc::new(values),
-                None,
-            ))
         }
         other => {
             return Err(unsupported(&format!("column type {other:?}")));

--- a/src/lancefmt/reader.rs
+++ b/src/lancefmt/reader.rs
@@ -149,6 +149,22 @@ fn leaf_of(dt: &DataType) -> StorageResult<Leaf> {
     }
 }
 
+/// The FL block holds 1024 values per chunk; a zero-width (constant)
+/// bitpacked chunk carries no packed words at all and decodes to zeros
+/// (review PR #96, finding 5).
+fn zeros_as<T>(values_in_chunk: u64) -> StorageResult<Vec<T>>
+where
+    T: Default + Clone,
+{
+    let n = values_in_chunk as usize;
+    if n > 1024 {
+        return Err(StorageError::Invalid(
+            "bitpacked chunk claims more than 1024 values".into(),
+        ));
+    }
+    Ok(vec![T::default(); n])
+}
+
 fn decode_chunk(
     buffer: &[u8],
     compression: &Compression,
@@ -213,6 +229,10 @@ fn decode_chunk(
                     return Err(StorageError::Invalid("bitpacked chunk too small".into()));
                 }
                 let width = u32::from_le_bytes(buffer[0..4].try_into().unwrap()) as usize;
+                if width == 0 {
+                    // constant / all-zero chunk: the packed block is empty
+                    return Ok(ChunkValues::U32(zeros_as::<u32>(values_in_chunk)?));
+                }
                 let packed = &buffer[4..];
                 if !packed.len().is_multiple_of(4) {
                     return Err(StorageError::Invalid(
@@ -233,7 +253,9 @@ fn decode_chunk(
                 }
                 let mut out = vec![0u32; 1024];
                 // SAFETY: `out` has exactly the FL block size for u32 and
-                // `words` holds one full block of packed words.
+                // `words` holds one full block of packed words. A zero width
+                // (constant chunk) has an empty block and is handled above
+                // the unpack via the `block_words == 0` short-circuit.
                 unsafe {
                     use lance_bitpacking::BitPacking;
                     <u32 as BitPacking>::unchecked_unpack(width, &words[..block_words], &mut out);
@@ -251,6 +273,10 @@ fn decode_chunk(
                     return Err(StorageError::Invalid("bitpacked chunk too small".into()));
                 }
                 let width = u32::from_le_bytes(buffer[0..4].try_into().unwrap()) as usize;
+                if width == 0 {
+                    // constant / all-zero chunk: the packed block is empty
+                    return Ok(ChunkValues::I64(zeros_as::<i64>(values_in_chunk)?));
+                }
                 let packed = &buffer[4..];
                 if !packed.len().is_multiple_of(8) {
                     return Err(StorageError::Invalid(
@@ -291,6 +317,10 @@ fn decode_chunk(
                     return Err(StorageError::Invalid("bitpacked chunk too small".into()));
                 }
                 let width = u32::from_le_bytes(buffer[0..4].try_into().unwrap()) as usize;
+                if width == 0 {
+                    // constant / all-zero chunk: the packed block is empty
+                    return Ok(ChunkValues::U64(zeros_as::<u64>(values_in_chunk)?));
+                }
                 let packed = &buffer[4..];
                 if !packed.len().is_multiple_of(8) {
                     return Err(StorageError::Invalid(
@@ -333,6 +363,10 @@ fn decode_chunk(
                     return Err(StorageError::Invalid(format!(
                         "u8 bitpacked width {width} exceeds 8 bits"
                     )));
+                }
+                if width == 0 {
+                    // constant / all-zero chunk: the packed block is empty
+                    return Ok(ChunkValues::U8(zeros_as::<u8>(values_in_chunk)?));
                 }
                 let packed = &buffer[4..];
                 let block_bytes = (1024usize * width).div_ceil(8);

--- a/src/lancefmt/schema.rs
+++ b/src/lancefmt/schema.rs
@@ -1,8 +1,9 @@
 //! Arrow schema <-> Lance field conversion for the supported type subset.
 //!
-//! Supported: `Float64` ("double"), `UInt32` ("uint32") and
-//! `FixedSizeList<Float64>` ("fixed_size_list:double:N"), all non-nullable
-//! at the top level. Anything else is rejected with
+//! Supported: `Float64` ("double"), `Float32` ("float"), `UInt8` ("uint8"),
+//! `UInt32` ("uint32"), `UInt64` ("uint64"), `Int64` ("int64") and
+//! `FixedSizeList<Float64|Float32>` ("fixed_size_list:double|float:N"), all
+//! non-nullable at the top level. Anything else is rejected with
 //! [`StorageError::UnsupportedFormat`] (never guessed, see #75).
 
 use std::sync::Arc;
@@ -19,11 +20,18 @@ pub(crate) const PLAIN_ENCODING: i32 = 1;
 pub(crate) fn logical_type_name(dt: &DataType) -> StorageResult<String> {
     match dt {
         DataType::Float64 => Ok("double".to_string()),
+        DataType::Float32 => Ok("float".to_string()),
+        DataType::UInt8 => Ok("uint8".to_string()),
         DataType::UInt32 => Ok("uint32".to_string()),
+        DataType::UInt64 => Ok("uint64".to_string()),
         DataType::Int64 => Ok("int64".to_string()),
-        DataType::FixedSizeList(child, n) if matches!(child.data_type(), DataType::Float64) => {
-            Ok(format!("fixed_size_list:double:{n}"))
-        }
+        DataType::FixedSizeList(child, n) => match child.data_type() {
+            DataType::Float64 => Ok(format!("fixed_size_list:double:{n}")),
+            DataType::Float32 => Ok(format!("fixed_size_list:float:{n}")),
+            other => Err(StorageError::UnsupportedFormat(format!(
+                "unsupported fixed_size_list item type for lancefmt: {other:?}"
+            ))),
+        },
         other => Err(StorageError::UnsupportedFormat(format!(
             "unsupported Arrow type for lancefmt: {other:?}"
         ))),
@@ -33,15 +41,24 @@ pub(crate) fn logical_type_name(dt: &DataType) -> StorageResult<String> {
 fn parse_logical_type(name: &str) -> StorageResult<DataType> {
     match name {
         "double" => Ok(DataType::Float64),
+        "float" => Ok(DataType::Float32),
+        "uint8" => Ok(DataType::UInt8),
         "uint32" => Ok(DataType::UInt32),
+        "uint64" => Ok(DataType::UInt64),
         "int64" => Ok(DataType::Int64),
         _ => {
-            if let Some(rest) = name.strip_prefix("fixed_size_list:double:") {
+            let fsl = match name.strip_prefix("fixed_size_list:double:") {
+                Some(rest) => Some((rest, DataType::Float64)),
+                None => name
+                    .strip_prefix("fixed_size_list:float:")
+                    .map(|rest| (rest, DataType::Float32)),
+            };
+            if let Some((rest, item)) = fsl {
                 let dim: i32 = rest.parse().map_err(|_| {
                     StorageError::UnsupportedFormat(format!("bad fixed_size_list dim: {name}"))
                 })?;
                 return Ok(DataType::FixedSizeList(
-                    Arc::new(Field::new("item", DataType::Float64, true)),
+                    Arc::new(Field::new("item", item, true)),
                     dim,
                 ));
             }

--- a/src/lancefmt/writer.rs
+++ b/src/lancefmt/writer.rs
@@ -7,9 +7,9 @@
 use std::path::Path;
 
 use arrow::array::{
-    Array, FixedSizeListArray, Float64Array, Int64Array, PrimitiveArray, UInt32Array,
+    Array, FixedSizeListArray, Float32Array, Float64Array, Int64Array, PrimitiveArray, UInt8Array,
+    UInt32Array, UInt64Array,
 };
-use arrow::datatypes::ArrowPrimitiveType;
 use arrow::datatypes::{DataType, Schema as ArrowSchema};
 use arrow::record_batch::RecordBatch;
 use prost::Message;
@@ -100,50 +100,24 @@ fn build_chunk(buffer: &[u8], ln: u16) -> StorageResult<Chunk> {
     Ok(Chunk { metadata, bytes })
 }
 
-fn chunk_bytes_le(
-    values: &PrimitiveArray<arrow::datatypes::Float64Type>,
-    values_per_chunk: usize,
-) -> StorageResult<Vec<Chunk>> {
-    chunk_bytes_le_impl(values, values_per_chunk, 8, |out, v| {
-        out.extend_from_slice(&v.to_le_bytes())
-    })
-}
-
-fn chunk_bytes_le_u32(
-    values: &PrimitiveArray<arrow::datatypes::UInt32Type>,
-    values_per_chunk: usize,
-) -> StorageResult<Vec<Chunk>> {
-    chunk_bytes_le_impl(values, values_per_chunk, 4, |out, v| {
-        out.extend_from_slice(&v.to_le_bytes())
-    })
-}
-
-fn chunk_bytes_le_i64(
-    values: &PrimitiveArray<arrow::datatypes::Int64Type>,
-    values_per_chunk: usize,
-) -> StorageResult<Vec<Chunk>> {
-    chunk_bytes_le_impl(values, values_per_chunk, 8, |out, v| {
-        out.extend_from_slice(&v.to_le_bytes())
-    })
-}
-
-fn chunk_bytes_le_impl<T: ArrowPrimitiveType>(
-    values: &PrimitiveArray<T>,
-    values_per_chunk: usize,
-    bytes_per_value: usize,
-    write_one: impl Fn(&mut Vec<u8>, T::Native),
+/// Encodes `total_items` flat LE values into chunks of `items_per_chunk`
+/// values; `full_chunk_ln` is the log2 value recorded for a full chunk
+/// (log2 of values for scalar columns, log2 of rows for FixedSizeList
+/// columns).
+fn chunked_items(
+    total_items: usize,
+    items_per_chunk: usize,
+    full_chunk_ln: u16,
+    mut write_items: impl FnMut(&mut Vec<u8>, usize, usize),
 ) -> StorageResult<Vec<Chunk>> {
     let mut chunks = Vec::new();
     let mut start = 0usize;
-    let total = values.len();
-    while start < total {
-        let n = values_per_chunk.min(total - start);
-        let mut buffer = Vec::with_capacity(n * bytes_per_value);
-        for i in start..start + n {
-            write_one(&mut buffer, values.value(i));
-        }
-        let ln = if n == values_per_chunk {
-            log2_usize(n)?
+    while start < total_items {
+        let n = items_per_chunk.min(total_items - start);
+        let mut buffer = Vec::with_capacity(n * 8);
+        write_items(&mut buffer, start, n);
+        let ln = if n == items_per_chunk {
+            full_chunk_ln
         } else {
             0
         };
@@ -153,7 +127,79 @@ fn chunk_bytes_le_impl<T: ArrowPrimitiveType>(
     Ok(chunks)
 }
 
-fn encode_column(batch: &RecordBatch, col: usize) -> StorageResult<EncodedPage> {
+fn chunk_bytes_le(
+    values: &PrimitiveArray<arrow::datatypes::Float64Type>,
+    values_per_chunk: usize,
+) -> StorageResult<Vec<Chunk>> {
+    let ln = log2_usize(values_per_chunk)?;
+    chunked_items(values.len(), values_per_chunk, ln, |out, s, n| {
+        for i in s..s + n {
+            out.extend_from_slice(&values.value(i).to_le_bytes())
+        }
+    })
+}
+
+fn chunk_bytes_le_f32(
+    values: &PrimitiveArray<arrow::datatypes::Float32Type>,
+    values_per_chunk: usize,
+) -> StorageResult<Vec<Chunk>> {
+    let ln = log2_usize(values_per_chunk)?;
+    chunked_items(values.len(), values_per_chunk, ln, |out, s, n| {
+        for i in s..s + n {
+            out.extend_from_slice(&values.value(i).to_le_bytes())
+        }
+    })
+}
+
+fn chunk_bytes_le_u32(
+    values: &PrimitiveArray<arrow::datatypes::UInt32Type>,
+    values_per_chunk: usize,
+) -> StorageResult<Vec<Chunk>> {
+    let ln = log2_usize(values_per_chunk)?;
+    chunked_items(values.len(), values_per_chunk, ln, |out, s, n| {
+        for i in s..s + n {
+            out.extend_from_slice(&values.value(i).to_le_bytes())
+        }
+    })
+}
+
+fn chunk_bytes_le_u64(
+    values: &PrimitiveArray<arrow::datatypes::UInt64Type>,
+    values_per_chunk: usize,
+) -> StorageResult<Vec<Chunk>> {
+    let ln = log2_usize(values_per_chunk)?;
+    chunked_items(values.len(), values_per_chunk, ln, |out, s, n| {
+        for i in s..s + n {
+            out.extend_from_slice(&values.value(i).to_le_bytes())
+        }
+    })
+}
+
+fn chunk_bytes_le_u8(
+    values: &PrimitiveArray<arrow::datatypes::UInt8Type>,
+    values_per_chunk: usize,
+) -> StorageResult<Vec<Chunk>> {
+    let ln = log2_usize(values_per_chunk)?;
+    chunked_items(values.len(), values_per_chunk, ln, |out, s, n| {
+        for i in s..s + n {
+            out.extend_from_slice(&values.value(i).to_le_bytes())
+        }
+    })
+}
+
+fn chunk_bytes_le_i64(
+    values: &PrimitiveArray<arrow::datatypes::Int64Type>,
+    values_per_chunk: usize,
+) -> StorageResult<Vec<Chunk>> {
+    let ln = log2_usize(values_per_chunk)?;
+    chunked_items(values.len(), values_per_chunk, ln, |out, s, n| {
+        for i in s..s + n {
+            out.extend_from_slice(&values.value(i).to_le_bytes())
+        }
+    })
+}
+
+fn encode_column(batch: &RecordBatch, col: usize) -> StorageResult<Vec<EncodedPage>> {
     let column = batch.column(col);
     let rows = column.len() as u64;
     let (chunks, value_compression, num_items) = match column.data_type() {
@@ -167,6 +213,36 @@ fn encode_column(batch: &RecordBatch, col: usize) -> StorageResult<EncodedPage> 
                 chunk_bytes_le(arr, 512)?,
                 Compression::Flat(Flat {
                     bits_per_value: 64,
+                    data: None,
+                }),
+                rows,
+            )
+        }
+        DataType::Float32 => {
+            let arr = column
+                .as_any()
+                .downcast_ref::<Float32Array>()
+                .ok_or_else(|| StorageError::Invalid("float32 downcast failed".into()))?;
+            // 1024 x 4B = 4KiB per chunk
+            (
+                chunk_bytes_le_f32(arr, 1024)?,
+                Compression::Flat(Flat {
+                    bits_per_value: 32,
+                    data: None,
+                }),
+                rows,
+            )
+        }
+        DataType::UInt8 => {
+            let arr = column
+                .as_any()
+                .downcast_ref::<UInt8Array>()
+                .ok_or_else(|| StorageError::Invalid("uint8 downcast failed".into()))?;
+            // 16384 x 1B = 16KiB per chunk
+            (
+                chunk_bytes_le_u8(arr, 16384)?,
+                Compression::Flat(Flat {
+                    bits_per_value: 8,
                     data: None,
                 }),
                 rows,
@@ -187,6 +263,21 @@ fn encode_column(batch: &RecordBatch, col: usize) -> StorageResult<EncodedPage> 
                 rows,
             )
         }
+        DataType::UInt64 => {
+            let arr = column
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .ok_or_else(|| StorageError::Invalid("uint64 downcast failed".into()))?;
+            // 1024 x 8B = 8KiB per chunk
+            (
+                chunk_bytes_le_u64(arr, 1024)?,
+                Compression::Flat(Flat {
+                    bits_per_value: 64,
+                    data: None,
+                }),
+                rows,
+            )
+        }
         DataType::Int64 => {
             let arr = column
                 .as_any()
@@ -202,7 +293,7 @@ fn encode_column(batch: &RecordBatch, col: usize) -> StorageResult<EncodedPage> 
                 rows,
             )
         }
-        DataType::FixedSizeList(_child, dim) => {
+        DataType::FixedSizeList(child, dim) => {
             let dim: i32 = *dim;
             let list = column
                 .as_any()
@@ -213,40 +304,129 @@ fn encode_column(batch: &RecordBatch, col: usize) -> StorageResult<EncodedPage> 
                     "lancefmt writer does not support nulls in FixedSizeList columns".into(),
                 ));
             }
-            let dim = dim as usize;
-            let values = list
-                .values()
-                .as_any()
-                .downcast_ref::<Float64Array>()
-                .ok_or_else(|| StorageError::Invalid("fsl child downcast failed".into()))?;
-            let bytes_per_row = dim * std::mem::size_of::<f64>();
-            let rows_per_chunk = (CHUNK_DATA_BUDGET / bytes_per_row).next_power_of_two();
-            let mut chunks = Vec::new();
-            let mut start = 0usize;
-            while start < values.len() {
-                let n_items = (rows_per_chunk * dim).min(values.len() - start);
-                let mut buffer = Vec::with_capacity(n_items * 8);
-                for i in start..start + n_items {
-                    buffer.extend_from_slice(&values.value(i).to_le_bytes());
+            let (bits, bytes_per_item) = match child.data_type() {
+                DataType::Float64 => (64u64, 8usize),
+                DataType::Float32 => (32u64, 4usize),
+                other => {
+                    return Err(StorageError::UnsupportedFormat(format!(
+                        "lancefmt writer: unsupported fixed_size_list item type {other:?}"
+                    )));
                 }
-                let ln = if n_items == rows_per_chunk * dim {
-                    log2_usize(rows_per_chunk)?
-                } else {
-                    0
-                };
-                chunks.push(build_chunk(&buffer, ln)?);
-                start += n_items;
+            };
+            let dim = dim as usize;
+            let bytes_per_row = dim * bytes_per_item;
+            // Rows per full chunk: a power of two so the chunk metadata can
+            // record log2(rows). The u16 chunk metadata word caps a chunk at
+            // 32768 bytes ((bytes/8 - 1) << 4 must fit in 12 bits), so a
+            // single row of `bytes_per_row` bytes must fit in that budget.
+            // When the 16KiB budget cannot hold even two rows (wide
+            // vectors), `rows_per_chunk` collapses to 1 and log2(1) = 0 is
+            // indistinguishable from the final-chunk marker; in that case
+            // the column is written as one page per row, each page a single
+            // final chunk (the shape the official writer emits for
+            // single-chunk pages).
+            if bytes_per_row > 32768 - 8 {
+                return Err(StorageError::UnsupportedFormat(format!(
+                    "lancefmt writer: fixed_size_list row of {bytes_per_row} bytes \
+                     exceeds the 32768-byte chunk metadata limit"
+                )));
             }
-            let compression = Compression::FixedSizeList(Box::new(FslCompressive {
-                items_per_value: dim as u64,
-                has_validity: false,
-                values: Some(Box::new(CompressiveEncoding {
-                    compression: Some(Compression::Flat(Flat {
-                        bits_per_value: 64,
-                        data: None,
+            let rows_per_chunk = (CHUNK_DATA_BUDGET / bytes_per_row).next_power_of_two();
+            let fsl_compression = || {
+                Compression::FixedSizeList(Box::new(FslCompressive {
+                    items_per_value: dim as u64,
+                    has_validity: false,
+                    values: Some(Box::new(CompressiveEncoding {
+                        compression: Some(Compression::Flat(Flat {
+                            bits_per_value: bits,
+                            data: None,
+                        })),
                     })),
-                })),
-            }));
+                }))
+            };
+            if rows_per_chunk <= 1 {
+                let items = list.values();
+                let mut pages = Vec::with_capacity(list.len());
+                for row in 0..list.len() {
+                    let mut buffer = Vec::with_capacity(bytes_per_row);
+                    let start = row * dim;
+                    match child.data_type() {
+                        DataType::Float64 => {
+                            let values =
+                                items
+                                    .as_any()
+                                    .downcast_ref::<Float64Array>()
+                                    .ok_or_else(|| {
+                                        StorageError::Invalid("fsl child downcast failed".into())
+                                    })?;
+                            for i in start..start + dim {
+                                buffer.extend_from_slice(&values.value(i).to_le_bytes());
+                            }
+                        }
+                        DataType::Float32 => {
+                            let values =
+                                items
+                                    .as_any()
+                                    .downcast_ref::<Float32Array>()
+                                    .ok_or_else(|| {
+                                        StorageError::Invalid("fsl child downcast failed".into())
+                                    })?;
+                            for i in start..start + dim {
+                                buffer.extend_from_slice(&values.value(i).to_le_bytes());
+                            }
+                        }
+                        other => {
+                            return Err(StorageError::UnsupportedFormat(format!(
+                                "lancefmt writer: unsupported fixed_size_list item type {other:?}"
+                            )));
+                        }
+                    }
+                    let chunk = build_chunk(&buffer, 0)?;
+                    pages.push(EncodedPage {
+                        metadata_buffer: chunk.metadata.to_le_bytes().to_vec(),
+                        data_buffer: chunk.bytes,
+                        rows: 1,
+                        num_items: 1,
+                        value_compression: fsl_compression(),
+                    });
+                }
+                return Ok(pages);
+            }
+            let items_per_chunk = rows_per_chunk * dim;
+            let full_chunk_ln = log2_usize(rows_per_chunk)?;
+            let total_items = list.values().len();
+            let chunks = match child.data_type() {
+                DataType::Float64 => {
+                    let values = list
+                        .values()
+                        .as_any()
+                        .downcast_ref::<Float64Array>()
+                        .ok_or_else(|| StorageError::Invalid("fsl child downcast failed".into()))?;
+                    chunked_items(total_items, items_per_chunk, full_chunk_ln, |buf, s, n| {
+                        for i in s..s + n {
+                            buf.extend_from_slice(&values.value(i).to_le_bytes());
+                        }
+                    })?
+                }
+                DataType::Float32 => {
+                    let values = list
+                        .values()
+                        .as_any()
+                        .downcast_ref::<Float32Array>()
+                        .ok_or_else(|| StorageError::Invalid("fsl child downcast failed".into()))?;
+                    chunked_items(total_items, items_per_chunk, full_chunk_ln, |buf, s, n| {
+                        for i in s..s + n {
+                            buf.extend_from_slice(&values.value(i).to_le_bytes());
+                        }
+                    })?
+                }
+                other => {
+                    return Err(StorageError::UnsupportedFormat(format!(
+                        "lancefmt writer: unsupported fixed_size_list item type {other:?}"
+                    )));
+                }
+            };
+            let compression = fsl_compression();
             (chunks, compression, rows)
         }
         other => {
@@ -263,13 +443,13 @@ fn encode_column(batch: &RecordBatch, col: usize) -> StorageResult<EncodedPage> 
         data_buffer.extend_from_slice(&chunk.bytes);
     }
 
-    Ok(EncodedPage {
+    Ok(vec![EncodedPage {
         metadata_buffer,
         data_buffer,
         rows,
         num_items,
         value_compression,
-    })
+    }])
 }
 
 fn page_layout(page: &EncodedPage) -> lfv2::Encoding {
@@ -319,17 +499,28 @@ pub fn write_dataset(batch: &RecordBatch, dir: &Path) -> StorageResult<()> {
     let mut column_metadatas: Vec<(u64, Vec<u8>)> = Vec::new();
 
     for col in 0..batch.num_columns() {
-        let page = encode_column(batch, col)?;
-        let page_encoding = page_layout(&page);
+        let pages = encode_column(batch, col)?;
+        let mut page_entries: Vec<column_metadata::Page> = Vec::with_capacity(pages.len());
+        for page in &pages {
+            let page_encoding = page_layout(page);
 
-        let mut buffers: Vec<&[u8]> = vec![&page.metadata_buffer, &page.data_buffer];
-        let mut page_buffer_offsets = Vec::with_capacity(buffers.len());
-        let mut page_buffer_sizes = Vec::with_capacity(buffers.len());
-        for b in buffers.drain(..) {
-            pad_to(&mut file_bytes, BUFFER_ALIGNMENT);
-            page_buffer_offsets.push(file_bytes.len() as u64);
-            page_buffer_sizes.push(b.len() as u64);
-            file_bytes.extend_from_slice(b);
+            let mut buffers: Vec<&[u8]> = vec![&page.metadata_buffer, &page.data_buffer];
+            let mut page_buffer_offsets = Vec::with_capacity(buffers.len());
+            let mut page_buffer_sizes = Vec::with_capacity(buffers.len());
+            for b in buffers.drain(..) {
+                pad_to(&mut file_bytes, BUFFER_ALIGNMENT);
+                page_buffer_offsets.push(file_bytes.len() as u64);
+                page_buffer_sizes.push(b.len() as u64);
+                file_bytes.extend_from_slice(b);
+            }
+
+            page_entries.push(column_metadata::Page {
+                buffer_offsets: page_buffer_offsets,
+                buffer_sizes: page_buffer_sizes,
+                length: page.rows,
+                encoding: Some(page_encoding),
+                priority: 0,
+            });
         }
 
         let column_metadata = ColumnMetadata {
@@ -340,13 +531,7 @@ pub fn write_dataset(batch: &RecordBatch, dir: &Path) -> StorageResult<()> {
                 }
                 .encode_to_vec(),
             )),
-            pages: vec![column_metadata::Page {
-                buffer_offsets: page_buffer_offsets,
-                buffer_sizes: page_buffer_sizes,
-                length: page.rows,
-                encoding: Some(page_encoding),
-                priority: 0,
-            }],
+            pages: page_entries,
             buffer_offsets: vec![],
             buffer_sizes: vec![],
         };
@@ -412,6 +597,10 @@ pub fn write_dataset(batch: &RecordBatch, dir: &Path) -> StorageResult<()> {
     let next_version = prev_version + 1;
     // Fragment ids are unique per dataset; version numbering gives us a
     // deterministic fresh id per overwrite (fresh dataset -> 0).
+    // NOTE (#95): this id == version-by-construction holds only while
+    // Overwrite is the sole operation. When Append lands (RFC #81), fragment
+    // ids must be allocated from `max_fragment_id` instead, since appended
+    // fragments coexist with previous versions' fragments.
     let fragment_id = prev_version;
 
     let data_file = DataFile {

--- a/src/lancefmt/writer.rs
+++ b/src/lancefmt/writer.rs
@@ -472,24 +472,83 @@ fn page_layout(page: &EncodedPage) -> lfv2::Encoding {
     direct_encoding("/lance.encodings21.PageLayout", layout.encode_to_vec())
 }
 
+/// Durable file write (#95-3): write to a unique tmp file next to `path`,
+/// fsync, then rename over `path`. The rename is the atomic publish point;
+/// the fsync makes the payload durable before the directory entry appears.
+fn write_durable(path: &Path, bytes: &[u8]) -> StorageResult<()> {
+    use std::io::Write;
+
+    let mut name = path
+        .file_name()
+        .ok_or_else(|| StorageError::Invalid(format!("bad artifact path {path:?}")))?
+        .to_os_string();
+    name.push(format!(".{}.tmp", uuid::Uuid::new_v4().simple()));
+    let tmp = path.with_file_name(name);
+
+    {
+        let mut f = std::fs::File::create(&tmp)
+            .map_err(|e| StorageError::Io(format!("create tmp for {path:?}: {e}")))?;
+        f.write_all(bytes)
+            .map_err(|e| StorageError::Io(format!("write tmp for {path:?}: {e}")))?;
+        f.sync_all()
+            .map_err(|e| StorageError::Io(format!("fsync tmp for {path:?}: {e}")))?;
+    }
+    std::fs::rename(&tmp, path).map_err(|e| StorageError::Io(format!("publish {path:?}: {e}")))?;
+    Ok(())
+}
+
+/// fsyncs a directory so a completed rename is itself durable
+/// (directory-entry durability, #95-3). No-op off unix.
+fn fsync_dir(dir: &Path) -> StorageResult<()> {
+    #[cfg(unix)]
+    {
+        let f = std::fs::File::open(dir)
+            .map_err(|e| StorageError::Io(format!("open dir {dir:?} for fsync: {e}")))?;
+        f.sync_all()
+            .map_err(|e| StorageError::Io(format!("fsync dir {dir:?}: {e}")))?;
+    }
+    #[cfg(not(unix))]
+    let _ = dir;
+    Ok(())
+}
+
 /// Writes `batch` as a single-fragment Lance v2.1 dataset rooted at `dir`.
+///
+/// Durability & concurrency (#95-3): the whole write — manifest-version
+/// allocation through commit-point publish — runs under a per-dataset write
+/// mailbox, and every artifact (data file, txn, manifest, version hint) is
+/// written tmp + fsync + rename with a directory fsync, in the order
+/// data → txn → manifest (commit) → hint. Readers observe either the
+/// previous or the complete new dataset version.
 pub fn write_dataset(batch: &RecordBatch, dir: &Path) -> StorageResult<()> {
     if batch.num_rows() == 0 {
         return Err(StorageError::Invalid(
             "lancefmt writer: empty batches are not supported".into(),
         ));
     }
-    let arrow_schema = batch.schema().as_ref().clone();
-    let (fields, schema_meta) = to_lance_schema(&arrow_schema)?;
 
     std::fs::create_dir_all(dir)
-        .map_err(|e| StorageError::Io(format!("create dataset dir {:?}: {e}", dir)))?;
+        .map_err(|e| StorageError::Io(format!("create dataset dir {dir:?}: {e}")))?;
     let data_dir = dir.join("data");
     let versions_dir = dir.join("_versions");
     let txn_dir = dir.join("_transactions");
     for d in [&data_dir, &versions_dir, &txn_dir] {
-        std::fs::create_dir_all(d).map_err(|e| StorageError::Io(format!("create {:?}: {e}", d)))?;
+        std::fs::create_dir_all(d).map_err(|e| StorageError::Io(format!("create {d:?}: {e}")))?;
     }
+
+    crate::commit::with_dataset_write_lock(dir, || {
+        write_dataset_locked(batch, &data_dir, &versions_dir, &txn_dir)
+    })
+}
+
+fn write_dataset_locked(
+    batch: &RecordBatch,
+    data_dir: &Path,
+    versions_dir: &Path,
+    txn_dir: &Path,
+) -> StorageResult<()> {
+    let arrow_schema = batch.schema().as_ref().clone();
+    let (fields, schema_meta) = to_lance_schema(&arrow_schema)?;
 
     let uuid = uuid::Uuid::new_v4();
     let data_file_name = format!("{:024b}{}.lance", 0, uuid.simple());
@@ -586,14 +645,14 @@ pub fn write_dataset(batch: &RecordBatch, dir: &Path) -> StorageResult<()> {
     file_bytes.extend_from_slice(b"LANC");
 
     let data_path = data_dir.join(&data_file_name);
-    std::fs::write(&data_path, &file_bytes)
-        .map_err(|e| StorageError::Io(format!("write {data_path:?}: {e}")))?;
+    write_durable(&data_path, &file_bytes)?;
+    fsync_dir(data_dir)?;
 
     // ---- manifest + transaction -----------------------------------------
     // Overwrite semantics (M4): an existing dataset receives a new manifest
     // version whose fragment set fully replaces the previous one; readers
     // (ours and official) open the highest version.
-    let prev_version = latest_manifest_version(&versions_dir)?;
+    let prev_version = latest_manifest_version(versions_dir)?;
     let next_version = prev_version + 1;
     // Fragment ids are unique per dataset; version numbering gives us a
     // deterministic fresh id per overwrite (fresh dataset -> 0).
@@ -670,11 +729,11 @@ pub fn write_dataset(batch: &RecordBatch, dir: &Path) -> StorageResult<()> {
         })),
     };
     let txn_bytes = transaction.encode_to_vec();
-    std::fs::write(
-        txn_dir.join(format!("{prev_version}-{uuid}.txn")),
+    write_durable(
+        &txn_dir.join(format!("{prev_version}-{uuid}.txn")),
         &txn_bytes,
-    )
-    .map_err(|e| StorageError::Io(format!("write txn: {e}")))?;
+    )?;
+    fsync_dir(txn_dir)?;
 
     let manifest_bytes = manifest.encode_to_vec();
     let mut out: Vec<u8> = Vec::new();
@@ -688,13 +747,17 @@ pub fn write_dataset(batch: &RecordBatch, dir: &Path) -> StorageResult<()> {
     out.extend_from_slice(&FILE_MAJOR.to_le_bytes());
     out.extend_from_slice(b"LANC");
 
-    std::fs::write(versions_dir.join(format!("{next_version}.manifest")), &out)
-        .map_err(|e| StorageError::Io(format!("write manifest: {e}")))?;
-    std::fs::write(
-        versions_dir.join("latest_version_hint.json"),
-        format!("{{\"version\":{next_version}}}"),
-    )
-    .map_err(|e| StorageError::Io(format!("write hint: {e}")))?;
+    // The manifest rename is the dataset's commit point; the directory
+    // fsync right after makes the published version durable.
+    write_durable(&versions_dir.join(format!("{next_version}.manifest")), &out)?;
+    fsync_dir(versions_dir)?;
+    // The hint is a discovery accelerator, not the commit pointer; it is
+    // still published atomically so a concurrent open never reads a
+    // truncated hint (#95).
+    write_durable(
+        &versions_dir.join("latest_version_hint.json"),
+        format!("{{\"version\":{next_version}}}").as_bytes(),
+    )?;
 
     Ok(())
 }

--- a/src/lancefmt/writer.rs
+++ b/src/lancefmt/writer.rs
@@ -516,10 +516,15 @@ fn fsync_dir(dir: &Path) -> StorageResult<()> {
 ///
 /// Durability & concurrency (#95-3): the whole write — manifest-version
 /// allocation through commit-point publish — runs under a per-dataset write
-/// mailbox, and every artifact (data file, txn, manifest, version hint) is
-/// written tmp + fsync + rename with a directory fsync, in the order
+/// mailbox (a blocking `std::sync::Mutex` held across several fsyncs), and
+/// every artifact (data file, txn, manifest, version hint) is written
+/// tmp + fsync + rename with a directory fsync, in the order
 /// data → txn → manifest (commit) → hint. Readers observe either the
 /// previous or the complete new dataset version.
+///
+/// Blocking: because of that lock, callers on Tokio must reach this through
+/// `spawn_blocking` (as `LanceStorage::write_lance_batch_async` does), never
+/// directly on an async executor thread.
 pub fn write_dataset(batch: &RecordBatch, dir: &Path) -> StorageResult<()> {
     if batch.num_rows() == 0 {
         return Err(StorageError::Invalid(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 #![allow(async_fn_in_trait)]
 pub mod catalog;
+pub mod commit;
 pub mod generations;
+pub mod graph;
 pub mod lance_storage_graph;
 pub mod lancefmt;
 pub mod metadata;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -2,13 +2,63 @@
 
 use log::{debug, info};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 
 use crate::StorageError;
 use crate::StorageResult;
 use crate::traits::backend::StorageBackend;
 use crate::traits::metadata::Metadata;
+
+/// First-class collection kind (RFC #81-P1).
+///
+/// Every named collection in the metadata registry is either a vector space
+/// (dense vector collections and scalar artifacts), a graph (edge/adjacency
+/// artifacts), or a plain table (anything else).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CollectionKind {
+    /// Dense vector collections (embeddings, maps, norms, lambdas, ...).
+    VectorSpace,
+    /// Graph data (edge lists, adjacency, laplacian).
+    Graph,
+    /// Anything else stored as a table.
+    Table,
+}
+
+impl CollectionKind {
+    /// Registry / descriptor string form (Generic Table API property value).
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            CollectionKind::VectorSpace => "vector-space",
+            CollectionKind::Graph => "graph",
+            CollectionKind::Table => "table",
+        }
+    }
+
+    /// Parses the string form ([`Self::as_str`]).
+    pub fn parse(s: &str) -> StorageResult<Self> {
+        match s {
+            "vector-space" => Ok(CollectionKind::VectorSpace),
+            "graph" => Ok(CollectionKind::Graph),
+            "table" => Ok(CollectionKind::Table),
+            other => Err(StorageError::Invalid(format!(
+                "unknown collection kind '{other}' (expected vector-space, graph or table)"
+            ))),
+        }
+    }
+
+    /// Derives the kind from a legacy artifact filetype; the compat shim
+    /// that turns the fixed artifact keys (`rawinput`, `adjacency`, ...)
+    /// into pre-seeded collections (RFC #81-P1).
+    pub fn for_filetype(filetype: &str) -> Option<Self> {
+        match filetype {
+            "dense" | "vectors" | "vector" => Some(CollectionKind::VectorSpace),
+            "sparse" | "graph" => Some(CollectionKind::Graph),
+            _ => None,
+        }
+    }
+}
 
 /// Represent a single file spec in the persistence directory
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -23,6 +73,14 @@ pub struct FileInfo {
     pub cols: usize,
     pub nnz: Option<usize>,
     pub size_bytes: Option<u64>,
+    /// First-class collection kind (RFC #81-P1); `None` for entries written
+    /// before 0.28 (kind is then derived from `filetype`).
+    #[serde(default)]
+    pub kind: Option<CollectionKind>,
+    /// User properties attached to the collection (RFC #81-P1), e.g. the
+    /// `graph` linkage of a vector space (RFC #81-P4).
+    #[serde(default)]
+    pub properties: BTreeMap<String, String>,
 }
 
 impl FileInfo {
@@ -49,15 +107,18 @@ impl FileInfo {
             cols: data_shape.1,
             nnz,
             size_bytes,
+            kind: CollectionKind::for_filetype(filetype),
+            properties: BTreeMap::new(),
         })
     }
 
     /// Assign the right format to the file type
     pub fn which_format(filetype: &str) -> StorageResult<String> {
         match filetype {
-            "dense" => Ok(String::from("lance fixed-row")),
+            "dense" | "vectors" => Ok(String::from("lance fixed-row")),
             "sparse" => Ok(String::from("lance row-major")),
             "vector" => Ok(String::from("lance row-major")),
+            "graph" => Ok(String::from("lance edge-list")),
             other => Err(StorageError::UnsupportedFormat(other.to_string())),
         }
     }
@@ -68,6 +129,7 @@ impl FileInfo {
             "rawinput" | "sub_centroids" | "dense" => Ok(String::from("dense")),
             "adjacency" | "laplacian" | "signals" | "sparse" => Ok(String::from("sparse")),
             "lambdas" | "item_norms" | "norms" | "vector" => Ok(String::from("vector")),
+            "graph" | "vectors" => Ok(filetype.into()),
             other => Err(StorageError::UnsupportedFiletype(other.to_string())),
         }
     }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,5 +1,6 @@
 mod lancefmt_common;
 mod test_catalog;
+mod test_collections;
 mod test_data;
 mod test_generations;
 mod test_lance_layer;
@@ -29,17 +30,8 @@ pub(crate) async fn tmp_dir(test_name: &str) -> PathBuf {
     d.canonicalize().unwrap_or(d)
 }
 
-// Logging harness
-use std::sync::Once;
-
-static INIT: Once = Once::new();
-
+// Logging harness: delegate to the crate-level initializer instead of
+// keeping a duplicate INIT static (#95).
 pub fn init() {
-    INIT.call_once(|| {
-        // Read RUST_LOG env variable, default to "info" if not set
-        let env = env_logger::Env::default().default_filter_or("debug");
-
-        // don't panic if called multiple times across binaries
-        let _ = env_logger::Builder::from_env(env).try_init();
-    });
+    crate::init();
 }

--- a/src/tests/test_catalog.rs
+++ b/src/tests/test_catalog.rs
@@ -1,7 +1,7 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 
-use crate::catalog::{Catalog, LocalRegistry, TableDescriptor};
+use crate::catalog::{Catalog, CollectionKind, LocalRegistry, TableDescriptor};
 use crate::lance_storage_graph::LanceStorageGraph;
 use crate::metadata::GeneMetadata;
 use crate::tests::tmp_dir;
@@ -60,6 +60,7 @@ async fn catalog_register_and_deregister_roundtrip() {
             name: "norms".to_string(),
             format: "lance".to_string(),
             base_location: base.join("catalog_test_norms.lance"),
+            kind: CollectionKind::VectorSpace,
             properties: HashMap::from([
                 ("filetype".to_string(), "vector".to_string()),
                 ("rows".to_string(), "100".to_string()),
@@ -98,6 +99,7 @@ async fn catalog_rejects_non_lance_format_and_bad_properties() {
             name: "delta_thing".to_string(),
             format: "delta".to_string(),
             base_location: base.join("delta_thing"),
+            kind: CollectionKind::Table,
             properties: Default::default(),
         })
         .unwrap_err();
@@ -108,11 +110,179 @@ async fn catalog_rejects_non_lance_format_and_bad_properties() {
             name: "bad_props".to_string(),
             format: "lance".to_string(),
             base_location: base.join("bad_props.lance"),
+            kind: CollectionKind::Table,
             properties: HashMap::from([("rows".to_string(), "many".to_string())])
                 .into_iter()
                 .collect(),
         })
         .unwrap_err();
+    assert!(matches!(err, crate::StorageError::Invalid(_)));
+}
+
+/// RFC #81-P1: legacy artifact keys become pre-seeded collections — kinds are
+/// derived from the filetype (dense/vector -> vector-space, sparse -> graph)
+/// and descriptors carry a `kind` property alongside the typed field.
+#[tokio::test(flavor = "multi_thread")]
+async fn catalog_derives_kinds_for_legacy_keys() {
+    let base = tmp_dir("catalog_m_c1").await;
+    let registry = registry_with(&base, "catalog_test");
+
+    let raw = registry.describe_table("rawinput").unwrap();
+    assert_eq!(raw.kind, CollectionKind::VectorSpace);
+    assert_eq!(
+        raw.properties.get("kind").map(String::as_str),
+        Some("vector-space")
+    );
+
+    let adj = registry.describe_table("adjacency").unwrap();
+    assert_eq!(adj.kind, CollectionKind::Graph);
+    assert_eq!(
+        adj.properties.get("kind").map(String::as_str),
+        Some("graph")
+    );
+}
+
+/// RFC #81-P1: user properties and an explicit kind round-trip through
+/// `register_table` -> `describe_table`, and are persisted inside the
+/// metadata `files` map (registry-level kinds).
+#[tokio::test(flavor = "multi_thread")]
+async fn catalog_kinds_and_user_properties_roundtrip() {
+    let base = tmp_dir("catalog_m_c1").await;
+    let mut registry = registry_with(&base, "catalog_test");
+
+    registry
+        .register_table(TableDescriptor {
+            name: "edges".to_string(),
+            format: "lance".to_string(),
+            base_location: base.join("catalog_test_edges.lance"),
+            kind: CollectionKind::Graph,
+            properties: BTreeMap::from([
+                ("filetype".to_string(), "graph".to_string()),
+                ("rows".to_string(), "7".to_string()),
+                ("cols".to_string(), "7".to_string()),
+                ("nnz".to_string(), "12".to_string()),
+                ("node_id_width".to_string(), "u32".to_string()),
+            ]),
+        })
+        .expect("register graph collection");
+
+    let desc = registry.describe_table("edges").unwrap();
+    assert_eq!(desc.kind, CollectionKind::Graph);
+    assert_eq!(
+        desc.properties.get("node_id_width").map(String::as_str),
+        Some("u32"),
+        "user properties pass through"
+    );
+
+    // the user property must be stored on the FileInfo itself
+    let metadata = registry.into_metadata();
+    let info = metadata.files.get("edges").unwrap();
+    assert_eq!(info.kind, Some(CollectionKind::Graph));
+    assert_eq!(
+        info.properties.get("node_id_width").map(String::as_str),
+        Some("u32")
+    );
+}
+
+/// RFC #81-P1: pre-0.28 metadata JSON (no `kind` / `properties` fields on
+/// FileInfo) still deserializes and the registry derives collection kinds.
+#[tokio::test(flavor = "multi_thread")]
+async fn catalog_legacy_metadata_json_still_loads() {
+    let legacy_json = r#"{
+        "name_id": "legacy_instance",
+        "nrows": 10,
+        "ncols": 5,
+        "base": "/tmp/legacy_instance",
+        "files": {
+            "rawinput": {
+                "filename": "legacy_instance_rawinput.lance",
+                "filetype": "dense",
+                "storage_format": "lance fixed-row",
+                "rows": 10,
+                "cols": 5,
+                "nnz": null,
+                "size_bytes": null
+            }
+        },
+        "created_at": "2026-01-01T00:00:00Z"
+    }"#;
+    let metadata: GeneMetadata = serde_json::from_str(legacy_json).expect("legacy JSON loads");
+    assert!(metadata.files["rawinput"].kind.is_none());
+    assert!(metadata.files["rawinput"].properties.is_empty());
+
+    let registry = LocalRegistry::new(metadata, std::path::PathBuf::from("/tmp/legacy_instance"));
+    let desc = registry.describe_table("rawinput").unwrap();
+    assert_eq!(desc.kind, CollectionKind::VectorSpace);
+}
+
+/// RFC #81-P4: `describe_vector_space` returns the vector-space descriptor
+/// plus the graph collection referenced by the `graph` user property.
+#[tokio::test(flavor = "multi_thread")]
+async fn catalog_describe_vector_space_links_graph() {
+    let base = tmp_dir("catalog_m_c1").await;
+    let mut registry = registry_with(&base, "catalog_test");
+
+    registry
+        .register_table(TableDescriptor {
+            name: "embeddings".to_string(),
+            format: "lance".to_string(),
+            base_location: base.join("catalog_test_embeddings.lance"),
+            kind: CollectionKind::VectorSpace,
+            properties: BTreeMap::from([
+                ("filetype".to_string(), "vectors".to_string()),
+                ("rows".to_string(), "100".to_string()),
+                ("cols".to_string(), "50".to_string()),
+                ("graph".to_string(), "adjacency".to_string()),
+            ]),
+        })
+        .expect("register vector space");
+
+    let vs = registry.describe_vector_space("embeddings").unwrap();
+    assert_eq!(vs.vectors.name, "embeddings");
+    let graph = vs.graph.expect("linked graph");
+    assert_eq!(graph.name, "adjacency");
+    assert_eq!(graph.kind, CollectionKind::Graph);
+
+    // a vector space without a graph link has no linked descriptor
+    registry
+        .register_table(TableDescriptor {
+            name: "bare".to_string(),
+            format: "lance".to_string(),
+            base_location: base.join("catalog_test_bare.lance"),
+            kind: CollectionKind::VectorSpace,
+            properties: BTreeMap::from([
+                ("filetype".to_string(), "vectors".to_string()),
+                ("rows".to_string(), "4".to_string()),
+                ("cols".to_string(), "4".to_string()),
+            ]),
+        })
+        .expect("register bare vector space");
+    assert!(
+        registry
+            .describe_vector_space("bare")
+            .unwrap()
+            .graph
+            .is_none()
+    );
+
+    // kind mismatches and dangling links are errors, not guesses
+    let err = registry.describe_vector_space("adjacency").unwrap_err();
+    assert!(matches!(err, crate::StorageError::Invalid(_)));
+    assert!(registry.describe_vector_space("missing").is_err());
+
+    registry
+        .register_table(TableDescriptor {
+            name: "dangling".to_string(),
+            format: "lance".to_string(),
+            base_location: base.join("catalog_test_dangling.lance"),
+            kind: CollectionKind::VectorSpace,
+            properties: BTreeMap::from([
+                ("filetype".to_string(), "vectors".to_string()),
+                ("graph".to_string(), "no_such_graph".to_string()),
+            ]),
+        })
+        .expect("register dangling vector space");
+    let err = registry.describe_vector_space("dangling").unwrap_err();
     assert!(matches!(err, crate::StorageError::Invalid(_)));
 }
 

--- a/src/tests/test_collections.rs
+++ b/src/tests/test_collections.rs
@@ -1,0 +1,580 @@
+//! Named collections, graphs and linkage (RFC #81-P1..P4).
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use arrow::array::{FixedSizeListArray, Float32Array, Float64Array, UInt32Array};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use smartcore::linalg::basic::arrays::Array2;
+use sprs::{CsMat, TriMat};
+
+use crate::catalog::{Catalog, CollectionKind, LocalRegistry};
+use crate::graph::{GraphEdge, GraphWriteOptions, NodeIdWidth, StoredGraph};
+use crate::lance_storage_graph::LanceStorageGraph;
+use crate::metadata::GeneMetadata;
+use crate::tests::tmp_dir;
+use crate::traits::backend::StorageBackend;
+use crate::traits::metadata::Metadata;
+
+async fn seeded_storage(name: &str) -> (PathBuf, LanceStorageGraph) {
+    let base = tmp_dir(name).await;
+    let storage = LanceStorageGraph::new(base.to_string_lossy().to_string(), name.to_string());
+    GeneMetadata::seed_metadata(name, 4, 4, &storage)
+        .await
+        .expect("seed metadata");
+    (base, storage)
+}
+
+fn f64_vector_batch(ids: &[u32], vectors: &[Vec<f64>]) -> RecordBatch {
+    let dim = vectors[0].len() as i32;
+    let flat: Vec<f64> = vectors.iter().flatten().copied().collect();
+    let child = Arc::new(Field::new("item", DataType::Float64, false));
+    let list =
+        FixedSizeListArray::new(child.clone(), dim, Arc::new(Float64Array::from(flat)), None);
+    let schema = Schema::new(vec![
+        Field::new("item_id", DataType::UInt32, false),
+        Field::new("vector", DataType::FixedSizeList(child, dim), false),
+    ]);
+    RecordBatch::try_new(
+        Arc::new(schema),
+        vec![
+            Arc::new(UInt32Array::from(ids.to_vec())) as _,
+            Arc::new(list) as _,
+        ],
+    )
+    .unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// P2: save_vectors / load_vectors
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn vectors_f64_roundtrip_with_id_column() {
+    let (_base, storage) = seeded_storage("vectors_f64").await;
+    let md_path = storage.metadata_path();
+
+    let ids = vec![10u32, 20, 30];
+    let vectors = vec![
+        vec![0.5, -1.25, 3.0, 7.0],
+        vec![0.0; 4],
+        vec![-2.5, 1.0, 0.125, 9.5],
+    ];
+    let batch = f64_vector_batch(&ids, &vectors);
+    storage
+        .save_vectors("embeddings", &batch, &md_path)
+        .await
+        .expect("save_vectors");
+
+    let loaded = storage
+        .load_vectors("embeddings")
+        .await
+        .expect("load_vectors");
+    assert_eq!(loaded.num_rows(), 3);
+    let ids_out = loaded
+        .column(0)
+        .as_any()
+        .downcast_ref::<UInt32Array>()
+        .unwrap();
+    for (i, e) in ids.iter().enumerate() {
+        assert_eq!(ids_out.value(i), *e);
+    }
+    let list = loaded
+        .column(1)
+        .as_any()
+        .downcast_ref::<FixedSizeListArray>()
+        .unwrap();
+    let values = list
+        .values()
+        .as_any()
+        .downcast_ref::<Float64Array>()
+        .unwrap();
+    for (i, e) in vectors.iter().flatten().enumerate() {
+        assert_eq!(values.value(i), *e, "vector value mismatch at {i}");
+    }
+
+    // dataset-level kind stamped into the schema metadata (RFC #81-P1)
+    assert_eq!(
+        loaded.schema().metadata().get("kind").map(String::as_str),
+        Some("vector-space")
+    );
+
+    // registry-level kind + properties
+    let md = storage.load_metadata().await.unwrap();
+    let info = md.files.get("embeddings").unwrap();
+    assert_eq!(info.kind, Some(CollectionKind::VectorSpace));
+    assert_eq!(info.properties.get("graph"), None);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn vectors_f32_roundtrip_bit_exact() {
+    let (_base, storage) = seeded_storage("vectors_f32").await;
+    let md_path = storage.metadata_path();
+
+    let dim = 2i32;
+    let values: Vec<f32> = vec![
+        0.0,
+        -0.0,
+        1.5,
+        -2.25,
+        f32::MIN_POSITIVE / 8.0,
+        f32::INFINITY,
+        0.123_456_79,
+        -0.999_999_9,
+    ];
+    let child = Arc::new(Field::new("item", DataType::Float32, false));
+    let list = FixedSizeListArray::new(
+        child.clone(),
+        dim,
+        Arc::new(Float32Array::from(values.clone())),
+        None,
+    );
+    let schema = Schema::new(vec![Field::new(
+        "vector",
+        DataType::FixedSizeList(child, dim),
+        false,
+    )]);
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(list) as _]).unwrap();
+
+    storage
+        .save_vectors("f32_maps", &batch, &md_path)
+        .await
+        .expect("save_vectors");
+    let loaded = storage
+        .load_vectors("f32_maps")
+        .await
+        .expect("load_vectors");
+    let out = loaded
+        .column(0)
+        .as_any()
+        .downcast_ref::<FixedSizeListArray>()
+        .unwrap()
+        .values()
+        .as_any()
+        .downcast_ref::<Float32Array>()
+        .unwrap();
+    assert_eq!(out.len(), values.len());
+    for (i, e) in values.iter().enumerate() {
+        assert_eq!(
+            out.value(i).to_bits(),
+            e.to_bits(),
+            "f32 bit-exact mismatch at {i}"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn vectors_rejects_invalid_schemas() {
+    let (_base, storage) = seeded_storage("vectors_invalid").await;
+    let md_path = storage.metadata_path();
+
+    // no FixedSizeList column
+    let schema = Schema::new(vec![Field::new("x", DataType::Float64, false)]);
+    let batch = RecordBatch::try_new(
+        Arc::new(schema),
+        vec![Arc::new(Float64Array::from(vec![1.0])) as _],
+    )
+    .unwrap();
+    let err = storage
+        .save_vectors("bad", &batch, &md_path)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, crate::StorageError::Invalid(_)),
+        "got {err:?}"
+    );
+
+    // nullable column
+    let child = Arc::new(Field::new("item", DataType::Float64, false));
+    let schema = Schema::new(vec![Field::new(
+        "vector",
+        DataType::FixedSizeList(child, 1),
+        true,
+    )]);
+    let list = FixedSizeListArray::new(
+        Arc::new(Field::new("item", DataType::Float64, false)),
+        1,
+        Arc::new(Float64Array::from(vec![1.0])),
+        None,
+    );
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(list) as _]).unwrap();
+    let err = storage
+        .save_vectors("bad", &batch, &md_path)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, crate::StorageError::Invalid(_)),
+        "got {err:?}"
+    );
+
+    // reserved user property
+    let batch = f64_vector_batch(&[1], &[vec![1.0]]);
+    let mut props = BTreeMap::new();
+    props.insert("kind".to_string(), "graph".to_string());
+    let err = storage
+        .save_vectors_with("bad", &batch, &props, &md_path)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, crate::StorageError::Invalid(_)),
+        "got {err:?}"
+    );
+}
+
+/// P1 compat shim: legacy fixed-key `save_dense` keeps working alongside the
+/// named-collection API, and both land in the registry with correct kinds.
+#[tokio::test(flavor = "multi_thread")]
+async fn legacy_save_dense_works_alongside_save_vectors() {
+    let (_base, storage) = seeded_storage("legacy_compat").await;
+    let md_path = storage.metadata_path();
+
+    let dense = vec![vec![1.0, 2.0], vec![3.0, 4.0]];
+    let matrix = smartcore::linalg::basic::matrix::DenseMatrix::<f64>::from_iterator(
+        dense.iter().flatten().copied(),
+        2,
+        2,
+        0,
+    );
+    storage
+        .save_dense("rawinput", &matrix, &md_path)
+        .await
+        .expect("legacy save_dense");
+
+    let batch = f64_vector_batch(&[0, 1], &dense);
+    storage
+        .save_vectors("modern", &batch, &md_path)
+        .await
+        .expect("save_vectors");
+
+    let md = storage.load_metadata().await.unwrap();
+    assert_eq!(md.files["rawinput"].kind, Some(CollectionKind::VectorSpace));
+    assert_eq!(md.files["modern"].kind, Some(CollectionKind::VectorSpace));
+
+    let registry = LocalRegistry::new(md, storage.base_path());
+    let desc = registry.describe_table("rawinput").unwrap();
+    assert_eq!(desc.kind, CollectionKind::VectorSpace);
+    assert_eq!(
+        desc.properties.get("kind").map(String::as_str),
+        Some("vector-space")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// P3: save_graph / load_graph / to_csr
+// ---------------------------------------------------------------------------
+
+/// Deterministic pseudo-random graph generator (no proptest dependency).
+fn generated_graph(n_nodes: u64, n_edges: usize, seed: u64, weighted: bool) -> Vec<GraphEdge> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    (0..n_edges)
+        .map(|_| {
+            let src = rng.random_range(0..n_nodes);
+            let dst = rng.random_range(0..n_nodes);
+            if weighted {
+                GraphEdge::weighted(src, dst, rng.random_range(-1.0..1.0))
+            } else {
+                GraphEdge::unweighted(src, dst)
+            }
+        })
+        .collect()
+}
+
+fn reference_csr(edges: &[GraphEdge], n: u64) -> CsMat<f64> {
+    let mut trimat = TriMat::new((n as usize, n as usize));
+    for e in edges {
+        let w = e.weight.map(f64::from).unwrap_or(1.0);
+        trimat.add_triplet(e.src as usize, e.dst as usize, w);
+    }
+    trimat.to_csr()
+}
+
+fn assert_graph_round_trip(graph: &StoredGraph, edges: &[GraphEdge], n: u64, weighted: bool) {
+    assert_eq!(graph.edges.len(), edges.len(), "edge count");
+    assert_eq!(graph.num_nodes, n, "node count");
+    assert_eq!(graph.weighted, weighted);
+    for (got, want) in graph.edges.iter().zip(edges.iter()) {
+        assert_eq!(got.src, want.src);
+        assert_eq!(got.dst, want.dst);
+        match (got.weight, want.weight) {
+            (Some(a), Some(b)) => assert_eq!(a.to_bits(), b.to_bits(), "weight bits"),
+            (None, None) => {}
+            other => panic!("weight presence mismatch: {other:?}"),
+        }
+    }
+    // CSR conversion matches a locally built reference
+    let csr = graph.to_csr().unwrap();
+    let reference = reference_csr(edges, n);
+    assert_eq!(csr.rows(), reference.rows());
+    assert_eq!(csr.nnz(), reference.nnz());
+    for (v, (r, c)) in csr.iter() {
+        let expected = reference.get(r, c).copied().unwrap_or(0.0);
+        assert_eq!(*v, expected, "csr value at ({r},{c})");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn graph_weighted_u32_roundtrip_generated() {
+    let (_base, storage) = seeded_storage("graph_u32").await;
+    let md_path = storage.metadata_path();
+
+    // sizes cross the u32/f32 chunk boundaries (512/1024 values per chunk)
+    for (n_nodes, n_edges, seed) in [(7u64, 1usize, 1), (50, 513, 2), (97, 1500, 3)] {
+        let edges = generated_graph(n_nodes, n_edges, seed, true);
+        storage
+            .save_graph(&format!("g_{seed}"), &edges, &md_path)
+            .await
+            .expect("save_graph");
+        let graph = storage
+            .load_graph(&format!("g_{seed}"))
+            .await
+            .expect("load_graph");
+        assert_eq!(graph.node_id_width, NodeIdWidth::U32);
+        assert_graph_round_trip(&graph, &edges, n_nodes, true);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn graph_topology_only_u64_roundtrip() {
+    let (_base, storage) = seeded_storage("graph_u64").await;
+    let md_path = storage.metadata_path();
+
+    // ids far above u32::MAX force the u64 schema; num_nodes keeps an
+    // isolated vertex (id u32::MAX + 2 exists, id u32::MAX + 3 does not)
+    let n = u32::MAX as u64 + 4;
+    let edges = vec![
+        GraphEdge::unweighted(0, n - 2),
+        GraphEdge::unweighted(n - 2, n - 1),
+        GraphEdge::unweighted(n - 1, 0),
+    ];
+    let options = GraphWriteOptions::with_width(NodeIdWidth::U64);
+    storage
+        .save_graph_with("topology", &edges, &options, &md_path)
+        .await
+        .expect("save_graph_with u64");
+
+    let graph = storage.load_graph("topology").await.expect("load_graph");
+    assert_eq!(graph.node_id_width, NodeIdWidth::U64);
+    assert!(!graph.weighted);
+    assert_graph_round_trip(&graph, &edges, n, false);
+
+    // unweighted CSR convention: weight 1.0
+    let csr = graph.to_csr().unwrap();
+    assert_eq!(
+        csr.get(0, (n - 2) as usize).copied(),
+        Some(1.0),
+        "topology-only edges get weight 1.0"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn graph_rejects_invalid_inputs() {
+    let (_base, storage) = seeded_storage("graph_invalid").await;
+    let md_path = storage.metadata_path();
+
+    // empty edge list
+    let err = storage
+        .save_graph("empty", &[], &md_path)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, crate::StorageError::Invalid(_)),
+        "got {err:?}"
+    );
+
+    // mixed weighted/topology edges
+    let mixed = vec![GraphEdge::weighted(0, 1, 0.5), GraphEdge::unweighted(1, 2)];
+    let err = storage
+        .save_graph("mixed", &mixed, &md_path)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, crate::StorageError::Invalid(_)),
+        "got {err:?}"
+    );
+
+    // u32 schema with a too-large id: Overflow, never truncation (#51)
+    let big = vec![GraphEdge::weighted(0, u32::MAX as u64 + 1, 0.5)];
+    let err = storage.save_graph("big", &big, &md_path).await.unwrap_err();
+    assert!(
+        matches!(err, crate::StorageError::Overflow(_)),
+        "got {err:?}"
+    );
+
+    // u64 schema accepts it
+    storage
+        .save_graph_with(
+            "big",
+            &big,
+            &GraphWriteOptions::with_width(NodeIdWidth::U64),
+            &md_path,
+        )
+        .await
+        .expect("u64 schema accepts ids above u32::MAX");
+
+    // num_nodes below max id + 1
+    let edges = vec![GraphEdge::unweighted(0, 5)];
+    let options = GraphWriteOptions {
+        num_nodes: Some(4),
+        ..Default::default()
+    };
+    let err = storage
+        .save_graph_with("small", &edges, &options, &md_path)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, crate::StorageError::Invalid(_)),
+        "got {err:?}"
+    );
+
+    // explicit num_nodes keeps isolated vertices
+    let options = GraphWriteOptions {
+        num_nodes: Some(10),
+        ..Default::default()
+    };
+    storage
+        .save_graph_with("sparse_graph", &edges, &options, &md_path)
+        .await
+        .expect("num_nodes override");
+    let graph = storage.load_graph("sparse_graph").await.unwrap();
+    assert_eq!(graph.num_nodes, 10, "isolated vertices preserved");
+    let csr = graph.to_csr().unwrap();
+    assert_eq!(csr.rows(), 10);
+}
+
+/// P3 + P1: the graph collection is registered with kind `graph` and its
+/// layout facts ride the registry properties.
+#[tokio::test(flavor = "multi_thread")]
+async fn graph_registry_kind_and_properties() {
+    let (_base, storage) = seeded_storage("graph_registry").await;
+    let md_path = storage.metadata_path();
+
+    let edges = generated_graph(5, 9, 7, true);
+    storage
+        .save_graph("laplacian_v2", &edges, &md_path)
+        .await
+        .unwrap();
+
+    let md = storage.load_metadata().await.unwrap();
+    let info = md.files.get("laplacian_v2").unwrap();
+    assert_eq!(info.kind, Some(CollectionKind::Graph));
+    assert_eq!(
+        info.properties.get("node_id_width").map(String::as_str),
+        Some("u32")
+    );
+    assert_eq!(
+        info.properties.get("weighted").map(String::as_str),
+        Some("true")
+    );
+    assert_eq!(
+        info.properties.get("num_nodes").map(String::as_str),
+        Some("5")
+    );
+
+    // dataset-level schema metadata carries the same facts
+    let batch = crate::lancefmt::scan_all(&storage.file_path("laplacian_v2")).unwrap();
+    let schema = batch.schema();
+    let meta = schema.metadata();
+    assert_eq!(meta.get("kind").map(String::as_str), Some("graph"));
+    assert_eq!(meta.get("weighted").map(String::as_str), Some("true"));
+}
+
+// ---------------------------------------------------------------------------
+// P4: vector-space <-> graph linkage
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn vector_space_links_graph_end_to_end() {
+    let (base, storage) = seeded_storage("linkage_e2e").await;
+    let md_path = storage.metadata_path();
+
+    // the linked graph
+    let edges = generated_graph(4, 6, 11, true);
+    storage
+        .save_graph("space_graph", &edges, &md_path)
+        .await
+        .expect("save_graph");
+
+    // the vector space referencing it by name (properties.graph)
+    let vectors: Vec<Vec<f64>> = (0..4)
+        .map(|row| (0..4).map(|c| 0.1 * (row * 4 + c) as f64).collect())
+        .collect();
+    let batch = f64_vector_batch(&[0, 1, 2, 3], &vectors);
+    let mut props = BTreeMap::new();
+    props.insert("graph".to_string(), "space_graph".to_string());
+    props.insert("tier".to_string(), "hot".to_string());
+    storage
+        .save_vectors_with("space_vectors", &batch, &props, &md_path)
+        .await
+        .expect("save_vectors_with");
+
+    // exact-value round trip through load_vectors
+    let loaded = storage
+        .load_vectors("space_vectors")
+        .await
+        .expect("load_vectors");
+    assert_eq!(loaded.num_rows(), 4);
+    assert_eq!(
+        loaded.schema().metadata().get("graph").map(String::as_str),
+        Some("space_graph"),
+        "user properties survive the round trip as dataset metadata"
+    );
+
+    // catalog-level helper resolves vectors + linked graph descriptors
+    let md = storage.load_metadata().await.unwrap();
+    let registry = LocalRegistry::new(md, base);
+    let vs = registry
+        .describe_vector_space("space_vectors")
+        .expect("describe_vector_space");
+    assert_eq!(vs.vectors.kind, CollectionKind::VectorSpace);
+    let graph = vs.graph.expect("linked graph");
+    assert_eq!(graph.name, "space_graph");
+    assert_eq!(graph.kind, CollectionKind::Graph);
+    assert_eq!(graph.properties.get("nnz").map(String::as_str), Some("6"));
+}
+
+// ---------------------------------------------------------------------------
+// Commit-actor serialization (duva base concurrency model)
+// ---------------------------------------------------------------------------
+
+/// Concurrent `save_*` calls must not lose each other's registry entries:
+/// every metadata read-modify-write cycle is serialized through the
+/// instance's commit actor.
+#[tokio::test(flavor = "multi_thread")]
+async fn concurrent_saves_do_not_lose_registry_entries() {
+    let (_base, storage) = seeded_storage("commit_actor").await;
+    let md_path = storage.metadata_path();
+
+    let mut handles = Vec::new();
+    for k in 0..12u32 {
+        let storage = storage.clone();
+        let md_path = md_path.clone();
+        handles.push(tokio::spawn(async move {
+            let vector = vec![k as f64, (k * 2) as f64, (k * 3) as f64];
+            storage
+                .save_vector(&format!("vec_{k}"), &vector, &md_path)
+                .await
+                .expect("save_vector");
+        }));
+    }
+    for h in handles {
+        h.await.expect("join");
+    }
+
+    let md = storage.load_metadata().await.unwrap();
+    for k in 0..12u32 {
+        assert!(
+            md.files.contains_key(&format!("vec_{k}")),
+            "registry entry vec_{k} was lost to a concurrent writer"
+        );
+    }
+
+    // RYOW: every committed artifact is loadable with exact values
+    for k in 0..12u32 {
+        let loaded = storage.load_vector(&format!("vec_{k}")).await.unwrap();
+        assert_eq!(loaded, vec![k as f64, (k * 2) as f64, (k * 3) as f64]);
+    }
+}

--- a/src/tests/test_collections.rs
+++ b/src/tests/test_collections.rs
@@ -12,7 +12,7 @@ use rand::{Rng, SeedableRng};
 use smartcore::linalg::basic::arrays::Array2;
 use sprs::{CsMat, TriMat};
 
-use crate::catalog::{Catalog, CollectionKind, LocalRegistry};
+use crate::catalog::{Catalog, CollectionKind, LocalRegistry, TableDescriptor};
 use crate::graph::{GraphEdge, GraphWriteOptions, NodeIdWidth, StoredGraph};
 use crate::lance_storage_graph::LanceStorageGraph;
 use crate::metadata::GeneMetadata;
@@ -359,12 +359,25 @@ async fn graph_topology_only_u64_roundtrip() {
     let graph = storage.load_graph("topology").await.expect("load_graph");
     assert_eq!(graph.node_id_width, NodeIdWidth::U64);
     assert!(!graph.weighted);
-    assert_graph_round_trip(&graph, &edges, n, false);
+    // Edge-list exactness only: CSR conversion allocates an O(num_nodes)
+    // indptr (~34 GB here) and is exercised separately on a small graph.
+    assert_eq!(graph.edges, edges);
+    assert_eq!(graph.num_nodes, n);
 
-    // unweighted CSR convention: weight 1.0
-    let csr = graph.to_csr().unwrap();
+    // unweighted CSR convention (weight 1.0) on a small-node u64 graph
+    let small_edges = vec![GraphEdge::unweighted(0, 2), GraphEdge::unweighted(2, 1)];
+    storage
+        .save_graph_with("topology_small", &small_edges, &options, &md_path)
+        .await
+        .expect("save_graph_with u64 small");
+    let small = storage
+        .load_graph("topology_small")
+        .await
+        .expect("load_graph u64 small");
+    assert_graph_round_trip(&small, &small_edges, 3, false);
+    let csr = small.to_csr().unwrap();
     assert_eq!(
-        csr.get(0, (n - 2) as usize).copied(),
+        csr.get(0, 2).copied(),
         Some(1.0),
         "topology-only edges get weight 1.0"
     );
@@ -577,4 +590,92 @@ async fn concurrent_saves_do_not_lose_registry_entries() {
         let loaded = storage.load_vector(&format!("vec_{k}")).await.unwrap();
         assert_eq!(loaded, vec![k as f64, (k * 2) as f64, (k * 3) as f64]);
     }
+}
+
+/// Review PR #96 finding 1: registry-reserved user properties are rejected
+/// on the direct write paths, same rule as `Catalog::register_table` — a
+/// caller-provided `rows`/`nnz`/... must not shadow computed facts.
+#[tokio::test(flavor = "multi_thread")]
+async fn write_paths_reject_registry_reserved_properties() {
+    let (_base, storage) = seeded_storage("reserved_props").await;
+    let md_path = storage.metadata_path();
+
+    let batch = f64_vector_batch(&[0, 1], &[vec![1.0, 2.0], vec![3.0, 4.0]]);
+
+    for reserved in [
+        "rows",
+        "cols",
+        "nnz",
+        "filetype",
+        "storage_format",
+        "size_bytes",
+    ] {
+        let mut props = BTreeMap::new();
+        props.insert(reserved.to_string(), "999".to_string());
+        let err = storage
+            .save_vectors_with("bad_vecs", &batch, &props, &md_path)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::StorageError::Invalid(_)),
+            "expected Invalid for '{reserved}', got {err:?}"
+        );
+
+        let edges = vec![GraphEdge::weighted(0, 1, 0.5)];
+        let options = GraphWriteOptions {
+            properties: props,
+            ..Default::default()
+        };
+        let err = storage
+            .save_graph_with("bad_graph", &edges, &options, &md_path)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::StorageError::Invalid(_)),
+            "expected Invalid for graph '{reserved}', got {err:?}"
+        );
+    }
+
+    // nothing was written for the rejected collections
+    let md = storage.load_metadata().await.unwrap();
+    assert!(md.files.get("bad_vecs").is_none());
+    assert!(md.files.get("bad_graph").is_none());
+}
+
+/// Review PR #96 finding 4: a `kind` property that contradicts the typed
+/// `kind` field is rejected instead of silently overriding it.
+#[tokio::test(flavor = "multi_thread")]
+async fn register_table_rejects_kind_mismatch() {
+    let base = tmp_dir("catalog_m_c1").await;
+    let mut registry = LocalRegistry::new(GeneMetadata::new("catalog_test"), base.to_path_buf());
+
+    let err = registry
+        .register_table(TableDescriptor {
+            name: "clashing".to_string(),
+            format: "lance".to_string(),
+            base_location: base.join("catalog_test_clashing.lance"),
+            kind: CollectionKind::VectorSpace,
+            properties: BTreeMap::from([("kind".to_string(), "graph".to_string())]),
+        })
+        .unwrap_err();
+    assert!(
+        matches!(err, crate::StorageError::Invalid(_)),
+        "got {err:?}"
+    );
+    assert!(!registry.table_exists("clashing").unwrap());
+
+    // agreement between the two sources of truth is fine
+    registry
+        .register_table(TableDescriptor {
+            name: "agreeing".to_string(),
+            format: "lance".to_string(),
+            base_location: base.join("catalog_test_agreeing.lance"),
+            kind: CollectionKind::Graph,
+            properties: BTreeMap::from([("kind".to_string(), "graph".to_string())]),
+        })
+        .expect("agreeing kinds register");
+    assert_eq!(
+        registry.describe_table("agreeing").unwrap().kind,
+        CollectionKind::Graph
+    );
 }

--- a/src/tests/test_lancefmt_impl.rs
+++ b/src/tests/test_lancefmt_impl.rs
@@ -540,3 +540,71 @@ fn impl_rejects_fsl_row_beyond_chunk_limit() {
         "expected UnsupportedFormat, got {err:?}"
     );
 }
+
+/// #95-3: concurrent write_dataset calls to the same dataset dir are
+/// serialized by the per-dataset write mailbox — manifest versions strictly
+/// increase (no lost overwrite) and the dataset stays readable.
+#[test]
+fn impl_concurrent_dataset_writes_keep_versions_monotonic() {
+    use std::sync::Arc as StdArc;
+    let dir = tmp_dir_sync("lancefmt_impl_concurrent_writes");
+
+    let make_batch = |v: f64| {
+        let schema = arrow::datatypes::Schema::new(vec![arrow::datatypes::Field::new(
+            "value",
+            arrow::datatypes::DataType::Float64,
+            false,
+        )]);
+        RecordBatch::try_new(
+            std::sync::Arc::new(schema),
+            vec![std::sync::Arc::new(Float64Array::from(vec![v; 4])) as _],
+        )
+        .unwrap()
+    };
+
+    let dir = StdArc::new(dir);
+    let mut handles = Vec::new();
+    for t in 0..8u32 {
+        let dir = dir.clone();
+        handles.push(std::thread::spawn(move || {
+            for k in 0..5u32 {
+                let batch = make_batch((t * 10 + k) as f64);
+                write_dataset(&batch, dir.as_path())
+                    .unwrap_or_else(|e| panic!("write {t}.{k} failed: {e}"));
+            }
+        }));
+    }
+    for h in handles {
+        h.join().expect("writer thread");
+    }
+
+    // exactly 8*5 manifest versions, strictly 1..=40
+    let versions_dir = dir.join("_versions");
+    let mut versions: Vec<u64> = std::fs::read_dir(&versions_dir)
+        .unwrap()
+        .filter_map(|e| {
+            let name = e.unwrap().file_name().to_string_lossy().to_string();
+            name.strip_suffix(".manifest")
+                .and_then(|stem| stem.parse().ok())
+        })
+        .collect();
+    versions.sort_unstable();
+    let expected: Vec<u64> = (1..=40).collect();
+    assert_eq!(versions, expected, "manifest versions must be 1..=40");
+
+    // the dataset is readable and corresponds to the highest version
+    let loaded = scan_all(&dir).expect("scan after concurrent writes");
+    assert_eq!(loaded.num_rows(), 4);
+
+    // no tmp staging residue left behind (#95-3)
+    for sub in ["data", "_versions", "_transactions"] {
+        let residue: Vec<_> = std::fs::read_dir(dir.join(sub))
+            .unwrap()
+            .filter_map(|e| {
+                let name = e.unwrap().file_name().to_string_lossy().to_string();
+                name.contains(".tmp").then_some(name)
+            })
+            .collect();
+        assert!(residue.is_empty(), "tmp residue in {sub}: {residue:?}");
+    }
+}

--- a/src/tests/test_lancefmt_impl.rs
+++ b/src/tests/test_lancefmt_impl.rs
@@ -237,3 +237,306 @@ fn assert_batch_i64(batch: &RecordBatch, expected: &[i64], col: usize, what: &st
         assert_eq!(arr.value(i), *e, "{what}: value mismatch at row {i}");
     }
 }
+
+// ---------------------------------------------------------------------------
+// RFC #81-P2: width-generic leaves (Float32 / UInt64 / UInt8 Flat, FSL<Float32>)
+// ---------------------------------------------------------------------------
+
+fn f32_values() -> Vec<f32> {
+    // bit-exact round-trip: include negatives, subnormals and infinities
+    [
+        0.0f32,
+        -0.0,
+        1.5,
+        -2.25,
+        f32::MIN_POSITIVE / 4.0,
+        f32::MAX,
+        f32::MIN,
+        f32::INFINITY,
+        0.123_456_79,
+        -0.9999999,
+    ]
+    .to_vec()
+}
+
+fn assert_batch_f32(batch: &RecordBatch, expected: &[f32], col: usize, what: &str) {
+    let arr = batch
+        .column(col)
+        .as_any()
+        .downcast_ref::<arrow::array::Float32Array>()
+        .unwrap_or_else(|| panic!("{what}: expected f32 column"));
+    assert_eq!(arr.len(), expected.len(), "{what}: row count");
+    for (i, e) in expected.iter().enumerate() {
+        assert_eq!(
+            arr.value(i).to_bits(),
+            e.to_bits(),
+            "{what}: bit-exact value mismatch at row {i}"
+        );
+    }
+}
+
+#[test]
+fn impl_roundtrip_float32_nonnull() {
+    let values = f32_values();
+    let arr = arrow::array::Float32Array::from(values.clone());
+    let schema = arrow::datatypes::Schema::new(vec![arrow::datatypes::Field::new(
+        "weight",
+        arrow::datatypes::DataType::Float32,
+        false,
+    )]);
+    let batch = RecordBatch::try_new(
+        std::sync::Arc::new(schema),
+        vec![std::sync::Arc::new(arr) as _],
+    )
+    .unwrap();
+    let dir = tmp_dir_sync("lancefmt_impl_f32");
+    write_dataset(&batch, &dir).expect("write");
+    let loaded = scan_all(&dir).expect("our scan");
+    assert_batch_f32(&loaded, &values, 0, "ours->ours f32");
+}
+
+#[test]
+fn impl_roundtrip_uint64_nonnull() {
+    let values: Vec<u64> = vec![0, 1, u32::MAX as u64, u32::MAX as u64 + 7, u64::MAX];
+    let arr = arrow::array::UInt64Array::from(values.clone());
+    let schema = arrow::datatypes::Schema::new(vec![arrow::datatypes::Field::new(
+        "id",
+        arrow::datatypes::DataType::UInt64,
+        false,
+    )]);
+    let batch = RecordBatch::try_new(
+        std::sync::Arc::new(schema),
+        vec![std::sync::Arc::new(arr) as _],
+    )
+    .unwrap();
+    let dir = tmp_dir_sync("lancefmt_impl_u64");
+    write_dataset(&batch, &dir).expect("write");
+    let loaded = scan_all(&dir).expect("our scan");
+    let out = loaded
+        .column(0)
+        .as_any()
+        .downcast_ref::<arrow::array::UInt64Array>()
+        .expect("u64 column");
+    for (i, e) in values.iter().enumerate() {
+        assert_eq!(out.value(i), *e, "u64 value mismatch at {i}");
+    }
+}
+
+#[test]
+fn impl_roundtrip_uint8_nonnull() {
+    let values: Vec<u8> = vec![0, 1, 42, 127, 128, 254, 255];
+    let arr = arrow::array::UInt8Array::from(values.clone());
+    let schema = arrow::datatypes::Schema::new(vec![arrow::datatypes::Field::new(
+        "q",
+        arrow::datatypes::DataType::UInt8,
+        false,
+    )]);
+    let batch = RecordBatch::try_new(
+        std::sync::Arc::new(schema),
+        vec![std::sync::Arc::new(arr) as _],
+    )
+    .unwrap();
+    let dir = tmp_dir_sync("lancefmt_impl_u8");
+    write_dataset(&batch, &dir).expect("write");
+    let loaded = scan_all(&dir).expect("our scan");
+    let out = loaded
+        .column(0)
+        .as_any()
+        .downcast_ref::<arrow::array::UInt8Array>()
+        .expect("u8 column");
+    for (i, e) in values.iter().enumerate() {
+        assert_eq!(out.value(i), *e, "u8 value mismatch at {i}");
+    }
+}
+
+#[test]
+fn impl_roundtrip_fsl_float32_nonnull() {
+    let dim = 3i32;
+    let values: Vec<f32> = (0..9).map(|i| i as f32 * 0.5 - 1.0).collect();
+    let child = std::sync::Arc::new(arrow::datatypes::Field::new(
+        "item",
+        arrow::datatypes::DataType::Float32,
+        false,
+    ));
+    let list = FixedSizeListArray::new(
+        child,
+        dim,
+        std::sync::Arc::new(arrow::array::Float32Array::from(values.clone())),
+        None,
+    );
+    let schema = arrow::datatypes::Schema::new(vec![arrow::datatypes::Field::new(
+        "vector",
+        arrow::datatypes::DataType::FixedSizeList(
+            std::sync::Arc::new(arrow::datatypes::Field::new(
+                "item",
+                arrow::datatypes::DataType::Float32,
+                false,
+            )),
+            dim,
+        ),
+        false,
+    )]);
+    let batch = RecordBatch::try_new(
+        std::sync::Arc::new(schema),
+        vec![std::sync::Arc::new(list) as _],
+    )
+    .unwrap();
+    let dir = tmp_dir_sync("lancefmt_impl_fsl_f32");
+    write_dataset(&batch, &dir).expect("write");
+    let loaded = scan_all(&dir).expect("our scan");
+    let list = loaded
+        .column(0)
+        .as_any()
+        .downcast_ref::<FixedSizeListArray>()
+        .expect("fsl column");
+    assert_eq!(list.value_length(), dim);
+    let out = list
+        .values()
+        .as_any()
+        .downcast_ref::<arrow::array::Float32Array>()
+        .expect("fsl child f32");
+    for (i, e) in values.iter().enumerate() {
+        assert_eq!(
+            out.value(i).to_bits(),
+            e.to_bits(),
+            "fsl f32 item mismatch at {i}"
+        );
+    }
+}
+
+/// Graph edge-list columns (RFC #81-P3) across chunk boundaries: 2500 rows
+/// with `src`/`dst` UInt32 and `weight` Float32 exercise multiple 512/1024-
+/// value chunks in one page.
+#[test]
+fn impl_roundtrip_graph_edge_list_multichunk() {
+    let n = 2500usize;
+    let src: Vec<u32> = (0..n as u32).map(|i| i % 97).collect();
+    let dst: Vec<u32> = (0..n as u32).map(|i| (i * 31 + 5) % 97).collect();
+    let weight: Vec<f32> = (0..n as u32).map(|i| (i as f32 / 97.0) - 12.5).collect();
+
+    let schema = arrow::datatypes::Schema::new(vec![
+        arrow::datatypes::Field::new("src", arrow::datatypes::DataType::UInt32, false),
+        arrow::datatypes::Field::new("dst", arrow::datatypes::DataType::UInt32, false),
+        arrow::datatypes::Field::new("weight", arrow::datatypes::DataType::Float32, false),
+    ]);
+    let batch = RecordBatch::try_new(
+        std::sync::Arc::new(schema),
+        vec![
+            std::sync::Arc::new(arrow::array::UInt32Array::from(src.clone())) as _,
+            std::sync::Arc::new(arrow::array::UInt32Array::from(dst.clone())) as _,
+            std::sync::Arc::new(arrow::array::Float32Array::from(weight.clone())) as _,
+        ],
+    )
+    .unwrap();
+    let dir = tmp_dir_sync("lancefmt_impl_graph_edges");
+    write_dataset(&batch, &dir).expect("write");
+    let loaded = scan_all(&dir).expect("our scan");
+    assert_eq!(loaded.num_rows(), n);
+
+    let s = loaded
+        .column(0)
+        .as_any()
+        .downcast_ref::<arrow::array::UInt32Array>()
+        .unwrap();
+    let d = loaded
+        .column(1)
+        .as_any()
+        .downcast_ref::<arrow::array::UInt32Array>()
+        .unwrap();
+    let w = loaded
+        .column(2)
+        .as_any()
+        .downcast_ref::<arrow::array::Float32Array>()
+        .unwrap();
+    for i in 0..n {
+        assert_eq!(s.value(i), src[i], "src mismatch at {i}");
+        assert_eq!(d.value(i), dst[i], "dst mismatch at {i}");
+        assert_eq!(
+            w.value(i).to_bits(),
+            weight[i].to_bits(),
+            "weight mismatch at {i}"
+        );
+    }
+}
+
+/// #95: wide vectors where the 16KiB budget cannot hold two rows
+/// (`rows_per_chunk` collapses to 1) must still round-trip — one page per
+/// row, each page a single final chunk.
+#[test]
+fn impl_roundtrip_fsl_wide_vectors() {
+    let dim = 3000i32; // 16KiB / (3000*8) == 0 -> rows_per_chunk would be 1
+    let values: Vec<f64> = (0..dim * 3).map(|i| (i % 17) as f64 - 8.0).collect();
+    let child = std::sync::Arc::new(arrow::datatypes::Field::new(
+        "item",
+        arrow::datatypes::DataType::Float64,
+        false,
+    ));
+    let list = FixedSizeListArray::new(
+        child.clone(),
+        dim,
+        std::sync::Arc::new(Float64Array::from(values.clone())),
+        None,
+    );
+    let schema = arrow::datatypes::Schema::new(vec![arrow::datatypes::Field::new(
+        "vector",
+        arrow::datatypes::DataType::FixedSizeList(child, dim),
+        false,
+    )]);
+    let batch = RecordBatch::try_new(
+        std::sync::Arc::new(schema),
+        vec![std::sync::Arc::new(list) as _],
+    )
+    .unwrap();
+    let dir = tmp_dir_sync("lancefmt_impl_fsl_wide");
+    write_dataset(&batch, &dir).expect("write wide fsl");
+    let loaded = scan_all(&dir).expect("our scan");
+    let out = loaded
+        .column(0)
+        .as_any()
+        .downcast_ref::<FixedSizeListArray>()
+        .expect("fsl column");
+    assert_eq!(out.value_length(), dim);
+    assert_eq!(out.len(), 3, "three wide rows");
+    let flat = out
+        .values()
+        .as_any()
+        .downcast_ref::<Float64Array>()
+        .expect("fsl child f64");
+    for (i, e) in values.iter().enumerate() {
+        assert_eq!(flat.value(i), *e, "wide fsl value mismatch at {i}");
+    }
+}
+
+/// A single row wider than the 32768-byte chunk-metadata limit is rejected
+/// explicitly instead of being mis-encoded.
+#[test]
+fn impl_rejects_fsl_row_beyond_chunk_limit() {
+    let dim = 4200i32; // 4200*8 = 33600 > 32760
+    let child = std::sync::Arc::new(arrow::datatypes::Field::new(
+        "item",
+        arrow::datatypes::DataType::Float64,
+        false,
+    ));
+    let list = FixedSizeListArray::new(
+        child.clone(),
+        dim,
+        std::sync::Arc::new(Float64Array::from(vec![0.0; dim as usize])),
+        None,
+    );
+    let schema = arrow::datatypes::Schema::new(vec![arrow::datatypes::Field::new(
+        "vector",
+        arrow::datatypes::DataType::FixedSizeList(child, dim),
+        false,
+    )]);
+    let batch = RecordBatch::try_new(
+        std::sync::Arc::new(schema),
+        vec![std::sync::Arc::new(list) as _],
+    )
+    .unwrap();
+    let dir = tmp_dir_sync("lancefmt_impl_fsl_too_wide");
+    let err = write_dataset(&batch, &dir).unwrap_err();
+    assert!(
+        matches!(err, crate::StorageError::UnsupportedFormat(_)),
+        "expected UnsupportedFormat, got {err:?}"
+    );
+}

--- a/src/tests/test_metadata.rs
+++ b/src/tests/test_metadata.rs
@@ -194,6 +194,8 @@ async fn test_metadata_roundtrip_with_sparse_info() {
             cols: 1000,
             nnz: Some(5000), // Sparse matrix with 5000 non-zero entries
             size_bytes: Some(120000),
+            kind: Some(crate::metadata::CollectionKind::Graph),
+            properties: std::collections::BTreeMap::new(),
         },
     );
 

--- a/src/traits/backend.rs
+++ b/src/traits/backend.rs
@@ -8,6 +8,7 @@ use sprs::{CsMat, TriMat};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use crate::graph::{GraphEdge, GraphWriteOptions, StoredGraph};
 use crate::metadata::GeneMetadata;
 use crate::{StorageError, StorageResult};
 
@@ -591,4 +592,66 @@ pub trait StorageBackend: Send + Sync {
     /// counterpart of [`Self::load_dense_from_file`]). Parent directories are
     /// created as needed.
     async fn save_dense_to_file(data: &DenseMatrix<f64>, path: &Path) -> StorageResult<()>;
+
+    // =========
+    // NAMED COLLECTIONS (RFC #81)
+    // =========
+
+    /// Saves a schema-driven vector-space collection (RFC #81-P2) without
+    /// user properties; see [`Self::save_vectors_with`].
+    ///
+    /// `save_dense` remains as the fixed-key `f64` wrapper for compat.
+    async fn save_vectors(
+        &self,
+        name: &str,
+        batch: &RecordBatch,
+        md_path: &Path,
+    ) -> StorageResult<()> {
+        self.save_vectors_with(name, batch, &Default::default(), md_path)
+            .await
+    }
+
+    /// Saves a vector-space collection with user properties (e.g. the
+    /// `graph` linkage of RFC #81-P4: `properties.graph = <name>`).
+    async fn save_vectors_with(
+        &self,
+        name: &str,
+        batch: &RecordBatch,
+        properties: &std::collections::BTreeMap<String, String>,
+        md_path: &Path,
+    ) -> StorageResult<()>;
+
+    /// Loads a vector-space collection back as a `RecordBatch` with its
+    /// original schema (including collection metadata).
+    async fn load_vectors(&self, name: &str) -> StorageResult<RecordBatch>;
+
+    /// Saves an edge-list graph collection (RFC #81-P3) with `u32` node ids
+    /// (the default width). Edges above `u32::MAX` surface
+    /// [`StorageError::Overflow`] instead of being truncated.
+    ///
+    /// The collection is either fully weighted (`weight: Float32` column) or
+    /// topology-only (`src`/`dst` only); mixed edges are rejected.
+    async fn save_graph(
+        &self,
+        name: &str,
+        edges: &[GraphEdge],
+        md_path: &Path,
+    ) -> StorageResult<()> {
+        self.save_graph_with(name, edges, &GraphWriteOptions::default(), md_path)
+            .await
+    }
+
+    /// Saves a graph collection with explicit options (node-id width,
+    /// node count, user properties for vector-space linkage, RFC #81-P4).
+    async fn save_graph_with(
+        &self,
+        name: &str,
+        edges: &[GraphEdge],
+        options: &GraphWriteOptions,
+        md_path: &Path,
+    ) -> StorageResult<()>;
+
+    /// Loads a graph collection back as an edge list; convert to CSR at the
+    /// API boundary with [`StoredGraph::to_csr`].
+    async fn load_graph(&self, name: &str) -> StorageResult<StoredGraph>;
 }

--- a/src/traits/lance.rs
+++ b/src/traits/lance.rs
@@ -7,10 +7,29 @@ use arrow::datatypes::{ArrowPrimitiveType, DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use log::{debug, info};
 
+use crate::catalog::RESERVED_PROPERTIES;
 use crate::graph::RESERVED_METADATA_KEYS;
 use crate::metadata::FileInfo;
 use crate::traits::backend::StorageBackend;
 use crate::{StorageError, StorageResult};
+
+/// Rejects user properties that would shadow computed registry facts
+/// (`RESERVED_PROPERTIES`, review of PR #96): the direct `save_*_with`
+/// write paths must enforce the same rule as `Catalog::register_table`, or
+/// a caller-provided `rows`/`nnz`/... would silently override the computed
+/// descriptor values.
+pub(crate) fn reject_reserved_user_properties(
+    properties: &BTreeMap<String, String>,
+) -> StorageResult<()> {
+    for key in properties.keys() {
+        if RESERVED_PROPERTIES.contains(&key.as_str()) {
+            return Err(StorageError::Invalid(format!(
+                "user property '{key}' is reserved (computed from the stored artifact)"
+            )));
+        }
+    }
+    Ok(())
+}
 
 /// Resolves a `file://` URI (as produced by `path_to_uri`) to a local path.
 fn uri_to_path(uri: &str) -> StorageResult<std::path::PathBuf> {

--- a/src/traits/lance.rs
+++ b/src/traits/lance.rs
@@ -1,11 +1,13 @@
+use std::collections::BTreeMap;
 use std::path::Path;
 use std::sync::Arc;
 
 use arrow::array::{ArrayRef, PrimitiveArray};
-use arrow::datatypes::{ArrowPrimitiveType, Field, Schema};
+use arrow::datatypes::{ArrowPrimitiveType, DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use log::{debug, info};
 
+use crate::graph::RESERVED_METADATA_KEYS;
 use crate::metadata::FileInfo;
 use crate::traits::backend::StorageBackend;
 use crate::{StorageError, StorageResult};
@@ -16,6 +18,87 @@ fn uri_to_path(uri: &str) -> StorageResult<std::path::PathBuf> {
         .map_err(|e| StorageError::Invalid(format!("bad dataset URI `{uri}`: {e}")))?;
     url.to_file_path().map_err(|_| {
         StorageError::Invalid(format!("dataset URI is not a local file path: `{uri}`"))
+    })
+}
+
+/// Stamps collection metadata (RFC #81-P1) into the batch schema: the
+/// dataset-level `kind`, writer-computed pairs, and the user properties.
+/// Existing schema metadata is preserved; user properties may not shadow
+/// reserved keys and the `kind` value always wins.
+pub(crate) fn with_collection_metadata(
+    batch: &RecordBatch,
+    kind: &str,
+    fixed: &[(&'static str, String)],
+    user_properties: &BTreeMap<String, String>,
+) -> StorageResult<RecordBatch> {
+    for key in user_properties.keys() {
+        if RESERVED_METADATA_KEYS.contains(&key.as_str()) {
+            return Err(StorageError::Invalid(format!(
+                "user property '{key}' is reserved by the collection metadata"
+            )));
+        }
+    }
+    let mut metadata = batch.schema().metadata().clone();
+    for (k, v) in fixed {
+        metadata.insert(k.to_string(), v.clone());
+    }
+    for (k, v) in user_properties {
+        metadata.insert(k.clone(), v.clone());
+    }
+    metadata.insert("kind".to_string(), kind.to_string());
+
+    let schema = Arc::new(batch.schema().as_ref().clone().with_metadata(metadata));
+    RecordBatch::try_new(schema, batch.columns().to_vec())
+        .map_err(|e| StorageError::Lance(e.to_string()))
+}
+
+/// Validates a vector-space schema (RFC #81-P2): at least one
+/// `FixedSizeList<Float64|Float32>` column, no nullable top-level fields,
+/// and any additional (id/property) columns limited to the lancefmt scalar
+/// subset. Returns the dimension of the first vector column.
+pub(crate) fn validate_vector_space_schema(schema: &Schema) -> StorageResult<(i32, DataType)> {
+    let fields = schema.fields();
+    if fields.is_empty() {
+        return Err(StorageError::Invalid(
+            "vector-space schema has no columns".into(),
+        ));
+    }
+    let mut vector_dim: Option<(i32, DataType)> = None;
+    for f in fields {
+        if f.is_nullable() {
+            return Err(StorageError::Invalid(format!(
+                "vector-space schemas require non-nullable columns; '{}' is nullable",
+                f.name()
+            )));
+        }
+        match f.data_type() {
+            DataType::FixedSizeList(child, dim)
+                if matches!(child.data_type(), DataType::Float64 | DataType::Float32) =>
+            {
+                if vector_dim.is_none() {
+                    vector_dim = Some((*dim, child.data_type().clone()));
+                }
+            }
+            DataType::Float32
+            | DataType::Float64
+            | DataType::UInt8
+            | DataType::UInt32
+            | DataType::UInt64
+            | DataType::Int64 => {}
+            other => {
+                return Err(StorageError::Invalid(format!(
+                    "vector-space id/property column '{}' has unsupported type {other:?}; \
+                     expected FixedSizeList<Float64|Float32> or a scalar column",
+                    f.name()
+                )));
+            }
+        }
+    }
+    vector_dim.ok_or_else(|| {
+        StorageError::Invalid(
+            "vector-space schema requires at least one FixedSizeList<Float64|Float32> column"
+                .into(),
+        )
     })
 }
 
@@ -76,18 +159,21 @@ pub trait LanceStorage {
         )
         .map_err(|e| StorageError::Lance(e.to_string()))?;
 
-        let mut metadata = self.load_metadata().await?;
-        metadata = metadata.add_file(
-            key,
-            FileInfo::new(
-                format!("{}_{}.lance", self.get_name(), key),
-                "vector",
-                (len, 1),
-                None,
-                None,
-            )?,
-        );
-        self.save_metadata(&metadata).await?;
+        crate::commit::with_commit_actor(&self.metadata_path(), || async {
+            let mut metadata = self.load_metadata().await?;
+            metadata = metadata.add_file(
+                key,
+                FileInfo::new(
+                    format!("{}_{}.lance", self.get_name(), key),
+                    "vector",
+                    (len, 1),
+                    None,
+                    None,
+                )?,
+            );
+            self.save_metadata(&metadata).await
+        })
+        .await?;
 
         let uri = Self::path_to_uri(&path)?;
         self.write_lance_batch_async(uri, batch).await?;


### PR DESCRIPTION
Closes #81 (P1–P4; P5 first increment landed in #94). Also addresses the small findings from #95.

## P1 — named collections & generic metadata
- `CollectionKind` (`vector-space` | `graph` | `table`), kebab-case serde
- `FileInfo` gains `kind` + user `properties` with `#[serde(default)]` — pre-0.28 metadata JSON loads untouched (compat shim: legacy artifact keys become pre-seeded collections)
- `TableDescriptor.kind` + user-property passthrough; computed props can't be shadowed

## P2 — generic dense vector collections
- `save_vectors` / `save_vectors_with` / `load_vectors`: schema-driven, any `FixedSizeList<Float64|Float32>` plus id/property scalar columns
- lancefmt additions (format-compatible, proto-confirmed logical types): `Float32`/`UInt64`/`UInt8` Flat, `FixedSizeList<Float32>`
- wide vectors (16KiB budget can't hold two rows) are written one page per row — fixes the #95 wide-FSL hang; a row beyond the 32768-byte chunk-metadata limit is rejected explicitly, never mis-encoded

## P3 — first-class graph storage
- canonical edge-list layout: `src`, `dst` (`UInt32` default, `UInt64` opt-in via `GraphWriteOptions`) + optional `weight: Float32`
- ids above the declared width surface `StorageError::Overflow` — no truncation (#51)
- `StoredGraph::to_csr()` keeps sprs at the API boundary; topology-only graphs get weight 1.0; explicit `num_nodes` preserves isolated vertices

## P4 — vector-space ↔ graph linkage
- `properties.graph = <name>` (registry + dataset schema metadata)
- `Catalog::describe_vector_space()` returns vectors + linked graph descriptors

## Concurrency safety (duva model)
- new `commit` module: a per-instance **commit actor** serializes every metadata read-modify-write cycle, so concurrent `save_*` calls cannot lose registry entries; RYOW covered by a 12-writer test
- `write_json_atomic` now stages into uuid-unique tmp files (#95)

## Tests
- 90 lib tests green (`cargo test --release --lib`), clippy clean, doctests pass
- new `test_collections.rs`: generated-graph round-trips (exact values, chunk-boundary sizes), u64 topology-only + isolated vertices, validation errors, legacy-JSON compat, linkage e2e, commit-actor concurrency
- new lancefmt tests: f32/u64/u8/FSL-f32 bit-exact round-trips, 2500-row multi-chunk edge list, wide-FSL multi-page, explicit over-limit rejection

## Follow-ups
- #95-3 (fsync of data/manifest/txn + directory fsync, version-hint atomicity) intentionally left open — tracked in #95
- #95-4 full pin/refcount reader semantics: doc contract added, refcounting future work