### PR TITLE
feat: reader pins for generation sweeps, weak-valued lock registries (#97, #98)

### DIFF
--- a/src/commit.rs
+++ b/src/commit.rs
@@ -44,7 +44,7 @@ static DATASET_LOCKS: OnceLock<StdMutex<HashMap<String, Weak<StdMutex<()>>>>> = 
 
 /// Shared weak-registry lookup (#98): reuse the live mailbox for `key` if
 /// one exists, otherwise sweep dead entries and insert `fresh`.
-fn weak_lookup<T>(
+pub(crate) fn weak_lookup<T>(
     registry: &'static OnceLock<StdMutex<HashMap<String, Weak<T>>>>,
     key: String,
     fresh: Arc<T>,

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -15,6 +15,12 @@
 //! commit-point publish of one dataset directory are serialized, so two
 //! concurrent overwrites cannot mint the same `N.manifest` (#95).
 //!
+//! Both registries hold **weak** references (#98): a mailbox stays alive
+//! only while some caller holds its `Arc` (i.e. while a commit cycle or
+//! dataset write is in flight), and dead entries are swept on insert.
+//! Instances that churn (create/drop thousands of collections) keep the
+//! registries bounded.
+//!
 //! Durability of the commit itself is the tmp + fsync + rename discipline
 //! ([`crate::generations::write_json_atomic`] for metadata, the same
 //! sequence inside the lancefmt writer for data/txn/manifest files):
@@ -25,24 +31,49 @@
 
 use std::collections::HashMap;
 use std::path::Path;
-use std::sync::{Arc, Mutex as StdMutex, OnceLock};
+use std::sync::{Arc, Mutex as StdMutex, OnceLock, Weak};
 
 use tokio::sync::Mutex;
 
 use crate::{StorageError, StorageResult};
 
-/// One commit-actor mailbox per metadata path (process-wide).
+/// Commit-actor mailboxes, keyed by metadata path (weak-valued, #98).
+static COMMIT_LOCKS: OnceLock<StdMutex<HashMap<String, Weak<Mutex<()>>>>> = OnceLock::new();
+/// Dataset-write mailboxes, keyed by dataset dir (weak-valued, #98).
+static DATASET_LOCKS: OnceLock<StdMutex<HashMap<String, Weak<StdMutex<()>>>>> = OnceLock::new();
+
+/// Shared weak-registry lookup (#98): reuse the live mailbox for `key` if
+/// one exists, otherwise sweep dead entries and insert `fresh`.
+fn weak_lookup<T>(
+    registry: &'static OnceLock<StdMutex<HashMap<String, Weak<T>>>>,
+    key: String,
+    fresh: Arc<T>,
+) -> Arc<T> {
+    let mut map = registry
+        .get_or_init(|| StdMutex::new(HashMap::new()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(weak) = map.get(&key)
+        && let Some(strong) = weak.upgrade()
+    {
+        return strong;
+    }
+    map.retain(|_, weak| weak.strong_count() > 0);
+    let arc = Arc::clone(&fresh);
+    map.insert(key, Arc::downgrade(&fresh));
+    arc
+}
+
+/// One commit-actor mailbox per metadata path.
 fn lock_for(metadata_path: &Path) -> Arc<Mutex<()>> {
-    static LOCKS: OnceLock<StdMutex<HashMap<String, Arc<Mutex<()>>>>> = OnceLock::new();
-    let locks = LOCKS.get_or_init(|| StdMutex::new(HashMap::new()));
     let key = metadata_path.to_string_lossy().to_string();
-    Arc::clone(
-        locks
-            .lock()
-            .expect("commit lock registry poisoned")
-            .entry(key)
-            .or_insert_with(|| Arc::new(Mutex::new(()))),
-    )
+    weak_lookup(&COMMIT_LOCKS, key, Arc::new(Mutex::new(())))
+}
+
+/// One dataset-write mailbox per dataset directory.
+fn dataset_lock_for(dataset_dir: &Path) -> Arc<StdMutex<()>> {
+    let key = dataset_dir.to_string_lossy().to_string();
+    weak_lookup(&DATASET_LOCKS, key, Arc::new(StdMutex::new(())))
 }
 
 /// Runs `commit` (a full metadata read-modify-write cycle) under the
@@ -61,26 +92,6 @@ where
     commit().await
 }
 
-/// One dataset-write mailbox per dataset directory (process-wide, sync —
-/// `write_dataset` runs on the blocking pool).
-///
-/// Serializes manifest-version allocation (`latest_manifest_version` →
-/// `+1`) against concurrent overwrites of the same dataset (#95): without
-/// it two writers could mint the same `N.manifest` and one overwrite would
-/// be silently lost.
-fn dataset_lock_for(dataset_dir: &Path) -> Arc<StdMutex<()>> {
-    static LOCKS: OnceLock<StdMutex<HashMap<String, Arc<StdMutex<()>>>>> = OnceLock::new();
-    let locks = LOCKS.get_or_init(|| StdMutex::new(HashMap::new()));
-    let key = dataset_dir.to_string_lossy().to_string();
-    Arc::clone(
-        locks
-            .lock()
-            .expect("dataset lock registry poisoned")
-            .entry(key)
-            .or_insert_with(|| Arc::new(StdMutex::new(()))),
-    )
-}
-
 /// Runs `write` under the dataset's write mailbox. `write` must be a
 /// non-async closure: the whole dataset write — version allocation through
 /// commit-point publish — happens under the lock.
@@ -93,4 +104,18 @@ pub(crate) fn with_dataset_write_lock<T>(
         .lock()
         .map_err(|_| StorageError::InvalidState("dataset write lock poisoned".into()))?;
     write()
+}
+
+/// Test hook: (commit-registry size, dataset-registry size).
+#[cfg(test)]
+pub(crate) fn registry_sizes() -> (usize, usize) {
+    let commit = COMMIT_LOCKS
+        .get()
+        .map(|m| m.lock().unwrap().len())
+        .unwrap_or(0);
+    let dataset = DATASET_LOCKS
+        .get()
+        .map(|m| m.lock().unwrap().len())
+        .unwrap_or(0);
+    (commit, dataset)
 }

--- a/src/generations.rs
+++ b/src/generations.rs
@@ -14,7 +14,9 @@
 //!   the complete new one, never a partial write.
 //! - `__g{digits}` at the end of an instance name is reserved.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex as StdMutex, OnceLock};
 
 use crate::{StorageError, StorageResult};
 
@@ -109,14 +111,19 @@ pub async fn list_artifact_generations(base: &Path, logical: &str) -> StorageRes
 /// `{logical}__g{gen}_`, so sibling datasets (`ds` vs `ds2`) are untouched.
 /// Safe to call on orphaned generations (no metadata) and on missing ones.
 ///
-/// Reader isolation (#95): there is no reference counting of in-flight
-/// readers. A sweep that removes a generation a reader is currently scanning
-/// will surface as an `Io` error mid-read; callers must serialize sweeps
-/// against reads (e.g. via the commit actor) or treat absence as
-/// "generation retired". Readers that need stable views should open by
-/// generation number and re-resolve on failure.
+/// Reader isolation (#97): if any [`GenerationGuard`] pin is alive for this
+/// generation, the sweep is refused with
+/// [`StorageError::InvalidState`] — it never removes artifacts under an
+/// in-flight reader. Callers retry once their readers have released.
 pub async fn delete_generation(base: &Path, logical: &str, generation: u64) -> StorageResult<()> {
     let prefix = format!("{logical}{GENERATION_SEP}{generation}_");
+    let metadata_path = base.join(format!("{prefix}metadata.json"));
+    if generation_pin_count(&metadata_path) > 0 {
+        return Err(StorageError::InvalidState(format!(
+            "generation {generation} of '{logical}' is pinned by an in-flight reader; \
+             sweep refused until all readers release"
+        )));
+    }
     let mut rd = tokio::fs::read_dir(base)
         .await
         .map_err(|e| StorageError::Io(e.to_string()))?;
@@ -140,6 +147,80 @@ pub async fn delete_generation(base: &Path, logical: &str, generation: u64) -> S
         }
     }
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Reader pins (#97)
+// ---------------------------------------------------------------------------
+
+/// Process-wide pin registry: metadata-path → live pin count. Counts hit
+/// zero only transiently (the dropping guard removes the entry), so the
+/// map stays bounded by the number of pinned generations.
+fn pin_registry() -> &'static StdMutex<HashMap<String, usize>> {
+    static PINS: OnceLock<StdMutex<HashMap<String, usize>>> = OnceLock::new();
+    PINS.get_or_init(|| StdMutex::new(HashMap::new()))
+}
+
+/// RAII pin on a committed generation (#97).
+///
+/// Acquired through [`pin_generation`]; while alive, it keeps one reference
+/// on the generation so a concurrent [`delete_generation`] refuses to touch
+/// it. Dropping the guard releases the reference; the last drop for a
+/// generation unregisters it.
+#[derive(Debug)]
+pub struct GenerationGuard {
+    key: String,
+}
+
+impl Drop for GenerationGuard {
+    fn drop(&mut self) {
+        let mut pins = pin_registry()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(count) = pins.get_mut(&self.key) {
+            *count -= 1;
+            if *count == 0 {
+                pins.remove(&self.key);
+            }
+        }
+    }
+}
+
+/// Pins a committed generation for the duration of a read (#97).
+///
+/// Registration is process-wide and refcounted: several readers may pin the
+/// same generation concurrently and all succeed; a sweep is refused while
+/// any pin is alive. Fails with [`StorageError::Invalid`] if the
+/// generation's metadata file (the commit pointer) does not exist —
+/// orphaned generations cannot be pinned.
+///
+/// Pin and sweep must address the generation through the same `base` path:
+/// the registry is keyed by the metadata file path.
+pub fn pin_generation(info: &GenerationInfo) -> StorageResult<GenerationGuard> {
+    if !info.metadata_path.is_file() {
+        return Err(StorageError::Invalid(format!(
+            "generation {} is not committed (no metadata at {:?}); \
+             only committed generations can be pinned",
+            info.generation, info.metadata_path
+        )));
+    }
+    let key = info.metadata_path.to_string_lossy().to_string();
+    let mut pins = pin_registry()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *pins.entry(key.clone()).or_insert(0) += 1;
+    Ok(GenerationGuard { key })
+}
+
+/// Live pin count for a generation, keyed by its metadata file path.
+fn generation_pin_count(metadata_path: &Path) -> usize {
+    let key = metadata_path.to_string_lossy().to_string();
+    pin_registry()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&key)
+        .copied()
+        .unwrap_or(0)
 }
 
 /// Atomic JSON publish: write to a unique `{path}.tmp`, fsync, rename over

--- a/src/generations.rs
+++ b/src/generations.rs
@@ -12,11 +12,15 @@
 //! - The commit itself is a single atomic filesystem operation
 //!   ([`write_json_atomic`]): readers observe either the previous file or
 //!   the complete new one, never a partial write.
+//! - Reader isolation (#97): pin acquisition (validation + registration) and
+//!   the sweep's check-to-retirement transition are serialized by a
+//!   per-generation state lock — a sweep never removes artifacts under a
+//!   registered reader, and a pin never registers for a retired generation.
 //! - `__g{digits}` at the end of an instance name is reserved.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex as StdMutex, OnceLock};
+use std::sync::{Arc, Mutex as StdMutex, OnceLock, Weak};
 
 use crate::{StorageError, StorageResult};
 
@@ -111,116 +115,141 @@ pub async fn list_artifact_generations(base: &Path, logical: &str) -> StorageRes
 /// `{logical}__g{gen}_`, so sibling datasets (`ds` vs `ds2`) are untouched.
 /// Safe to call on orphaned generations (no metadata) and on missing ones.
 ///
-/// Reader isolation (#97): if any [`GenerationGuard`] pin is alive for this
-/// generation, the sweep is refused with
-/// [`StorageError::InvalidState`] — it never removes artifacts under an
-/// in-flight reader. Callers retry once their readers have released.
+/// Reader isolation (#97): the pin check through the *complete removal* runs
+/// inside one per-generation state lock — the retirement transition is
+/// atomic with respect to [`pin_generation`], which validates and registers
+/// under that same lock. A pin attempt that races a sweep either precedes
+/// the sweep's lock acquisition (the sweep then sees the pin and is refused
+/// with [`StorageError::InvalidState`]) or waits for retirement to finish
+/// (and then fails validation, because the commit pointer is gone). A sweep
+/// can therefore never delete underneath a registered reader. Callers retry
+/// a refused sweep once their readers have released.
 pub async fn delete_generation(base: &Path, logical: &str, generation: u64) -> StorageResult<()> {
     let prefix = format!("{logical}{GENERATION_SEP}{generation}_");
     let metadata_path = base.join(format!("{prefix}metadata.json"));
-    if generation_pin_count(&metadata_path) > 0 {
-        return Err(StorageError::InvalidState(format!(
-            "generation {generation} of '{logical}' is pinned by an in-flight reader; \
-             sweep refused until all readers release"
-        )));
-    }
-    let mut rd = tokio::fs::read_dir(base)
-        .await
-        .map_err(|e| StorageError::Io(e.to_string()))?;
-    while let Some(entry) = rd
-        .next_entry()
-        .await
-        .map_err(|e| StorageError::Io(e.to_string()))?
-    {
-        if !entry.file_name().to_string_lossy().starts_with(&prefix) {
-            continue;
+    // Resolve (or mint) the generation's state lock up front, then run the
+    // whole check-to-retirement critical section synchronously under it on
+    // the blocking pool: std locks must not be held across awaits.
+    let state = crate::commit::weak_lookup(
+        &GENERATION_STATES,
+        metadata_path.to_string_lossy().to_string(),
+        Arc::new(StdMutex::new(GenerationState::default())),
+    );
+    sweep_gate(SWEEP_GATE_PRE_LOCK);
+    let base = base.to_path_buf();
+    let logical = logical.to_string();
+    tokio::task::spawn_blocking(move || -> StorageResult<()> {
+        let state = state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.pins > 0 {
+            return Err(StorageError::InvalidState(format!(
+                "generation {generation} of '{logical}' is pinned by an in-flight reader; \
+                 sweep refused until all readers release"
+            )));
         }
-        let path = entry.path();
-        if path.is_dir() {
-            tokio::fs::remove_dir_all(&path)
-                .await
-                .map_err(|e| StorageError::Io(e.to_string()))?;
-        } else {
-            tokio::fs::remove_file(&path)
-                .await
-                .map_err(|e| StorageError::Io(e.to_string()))?;
+        // Past the check and still under the lock: no pin can register for
+        // this generation until the removals complete (test hook forces a
+        // pin attempt exactly in this window).
+        sweep_gate(SWEEP_GATE_POST_CHECK);
+        let rd = std::fs::read_dir(&base)
+            .map_err(|e| StorageError::Io(format!("read {base:?}: {e}")))?;
+        let mut removed = Vec::new();
+        for entry in rd {
+            let entry = entry.map_err(|e| StorageError::Io(e.to_string()))?;
+            if !entry.file_name().to_string_lossy().starts_with(&prefix) {
+                continue;
+            }
+            removed.push(entry.path());
         }
-    }
-    Ok(())
+        for path in removed {
+            if path.is_dir() {
+                std::fs::remove_dir_all(&path)
+                    .map_err(|e| StorageError::Io(format!("remove {path:?}: {e}")))?;
+            } else {
+                std::fs::remove_file(&path)
+                    .map_err(|e| StorageError::Io(format!("remove {path:?}: {e}")))?;
+            }
+        }
+        Ok(())
+    })
+    .await
+    .map_err(|e| StorageError::Io(format!("generation sweep task failed: {e}")))?
 }
 
 // ---------------------------------------------------------------------------
 // Reader pins (#97)
 // ---------------------------------------------------------------------------
 
-/// Process-wide pin registry: metadata-path → live pin count. Counts hit
-/// zero only transiently (the dropping guard removes the entry), so the
-/// map stays bounded by the number of pinned generations.
-fn pin_registry() -> &'static StdMutex<HashMap<String, usize>> {
-    static PINS: OnceLock<StdMutex<HashMap<String, usize>>> = OnceLock::new();
-    PINS.get_or_init(|| StdMutex::new(HashMap::new()))
+/// Per-generation pin state; the lock guarding the state serializes pin
+/// registration/validation against the sweep's retirement transition.
+#[derive(Debug, Default)]
+struct GenerationState {
+    pins: usize,
 }
+
+/// Weak-valued registry of per-generation state locks (the #98 discipline):
+/// entries live only while a pin or an in-flight sweep holds the `Arc`.
+static GENERATION_STATES: OnceLock<StdMutex<HashMap<String, Weak<StdMutex<GenerationState>>>>> =
+    OnceLock::new();
 
 /// RAII pin on a committed generation (#97).
 ///
 /// Acquired through [`pin_generation`]; while alive, it keeps one reference
-/// on the generation so a concurrent [`delete_generation`] refuses to touch
-/// it. Dropping the guard releases the reference; the last drop for a
-/// generation unregisters it.
+/// on the generation's state so a concurrent [`delete_generation`] refuses
+/// to touch it. Dropping the guard releases the reference.
 #[derive(Debug)]
 pub struct GenerationGuard {
-    key: String,
+    state: Arc<StdMutex<GenerationState>>,
 }
 
 impl Drop for GenerationGuard {
     fn drop(&mut self) {
-        let mut pins = pin_registry()
+        let mut state = self
+            .state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if let Some(count) = pins.get_mut(&self.key) {
-            *count -= 1;
-            if *count == 0 {
-                pins.remove(&self.key);
-            }
-        }
+        state.pins -= 1;
     }
 }
 
 /// Pins a committed generation for the duration of a read (#97).
 ///
-/// Registration is process-wide and refcounted: several readers may pin the
+/// Registration is refcounted per generation: several readers may pin the
 /// same generation concurrently and all succeed; a sweep is refused while
-/// any pin is alive. Fails with [`StorageError::Invalid`] if the
-/// generation's metadata file (the commit pointer) does not exist —
-/// orphaned generations cannot be pinned.
+/// any pin is alive. Validation (commit pointer exists) and registration
+/// happen atomically with respect to [`delete_generation`]'s retirement
+/// transition — both hold the generation's state lock, so a racing sweep
+/// either observes this pin (and is refused) or has already retired the
+/// generation (and this call fails validation).
 ///
-/// Pin and sweep must address the generation through the same `base` path:
-/// the registry is keyed by the metadata file path.
+/// Fails with [`StorageError::Invalid`] if the generation's metadata file
+/// (the commit pointer) does not exist — orphaned generations cannot be
+/// pinned. Pin and sweep must address the generation through the same
+/// `base` path: state is keyed by the metadata file path.
 pub fn pin_generation(info: &GenerationInfo) -> StorageResult<GenerationGuard> {
-    if !info.metadata_path.is_file() {
-        return Err(StorageError::Invalid(format!(
-            "generation {} is not committed (no metadata at {:?}); \
-             only committed generations can be pinned",
-            info.generation, info.metadata_path
-        )));
+    let state = crate::commit::weak_lookup(
+        &GENERATION_STATES,
+        info.metadata_path.to_string_lossy().to_string(),
+        Arc::new(StdMutex::new(GenerationState::default())),
+    );
+    {
+        let mut guard = state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // Validation under the state lock: a concurrent sweep either
+        // finished its retirement (metadata gone -> rejected here) or waits
+        // for this pin to register (and is then refused).
+        if !info.metadata_path.is_file() {
+            return Err(StorageError::Invalid(format!(
+                "generation {} is not committed (no metadata at {:?}); \
+                 only committed generations can be pinned",
+                info.generation, info.metadata_path
+            )));
+        }
+        guard.pins += 1;
     }
-    let key = info.metadata_path.to_string_lossy().to_string();
-    let mut pins = pin_registry()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    *pins.entry(key.clone()).or_insert(0) += 1;
-    Ok(GenerationGuard { key })
-}
-
-/// Live pin count for a generation, keyed by its metadata file path.
-fn generation_pin_count(metadata_path: &Path) -> usize {
-    let key = metadata_path.to_string_lossy().to_string();
-    pin_registry()
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .get(&key)
-        .copied()
-        .unwrap_or(0)
+    Ok(GenerationGuard { state })
 }
 
 /// Atomic JSON publish: write to a unique `{path}.tmp`, fsync, rename over
@@ -276,4 +305,64 @@ async fn scan_generation_paths(base: &Path, logical: &str) -> StorageResult<Vec<
         }
     }
     Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// Test-only sweep gates (PR #99 review): force deterministic interleavings
+// of pin attempts against the sweep's critical section.
+// ---------------------------------------------------------------------------
+
+pub(crate) const SWEEP_GATE_PRE_LOCK: usize = 0;
+pub(crate) const SWEEP_GATE_POST_CHECK: usize = 1;
+
+// Non-test builds compile the gate calls away entirely.
+#[cfg(not(test))]
+fn sweep_gate(_stage: usize) {}
+
+#[cfg(test)]
+fn sweep_gates() -> &'static StdMutex<[Option<SweepGate>; 2]> {
+    static GATES: OnceLock<StdMutex<[Option<SweepGate>; 2]>> = OnceLock::new();
+    GATES.get_or_init(|| StdMutex::new([None, None]))
+}
+
+/// A gate the sweep must pass through: it signals `arrived` (so tests know
+/// the sweep is parked exactly at the stage) and blocks until `release`.
+#[cfg(test)]
+struct SweepGate {
+    arrived: std::sync::mpsc::Sender<()>,
+    release: std::sync::mpsc::Receiver<()>,
+}
+
+/// Arms a gate: the next sweep to reach `stage` signals the returned
+/// receiver and parks until the returned sender fires. Fires once.
+#[cfg(test)]
+pub(crate) fn arm_sweep_gate(
+    stage: usize,
+) -> (std::sync::mpsc::Receiver<()>, std::sync::mpsc::Sender<()>) {
+    let (arrived_tx, arrived_rx) = std::sync::mpsc::channel();
+    let (release_tx, release_rx) = std::sync::mpsc::channel();
+    let mut gates = sweep_gates()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    gates[stage] = Some(SweepGate {
+        arrived: arrived_tx,
+        release: release_rx,
+    });
+    (arrived_rx, release_tx)
+}
+
+/// Blocks the sweep at `stage` if a gate is armed there (consumes it).
+#[cfg(test)]
+fn sweep_gate(stage: usize) {
+    let gate = sweep_gates()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get_mut(stage)
+        .unwrap()
+        .take();
+    if let Some(gate) = gate {
+        // park: the test now knows exactly where the sweep is
+        let _ = gate.arrived.send(());
+        let _ = gate.release.recv();
+    }
 }

--- a/src/tests/test_collections.rs
+++ b/src/tests/test_collections.rs
@@ -638,8 +638,8 @@ async fn write_paths_reject_registry_reserved_properties() {
 
     // nothing was written for the rejected collections
     let md = storage.load_metadata().await.unwrap();
-    assert!(md.files.get("bad_vecs").is_none());
-    assert!(md.files.get("bad_graph").is_none());
+    assert!(!md.files.contains_key("bad_vecs"));
+    assert!(!md.files.contains_key("bad_graph"));
 }
 
 /// Review PR #96 finding 4: a `kind` property that contradicts the typed

--- a/src/tests/test_generations.rs
+++ b/src/tests/test_generations.rs
@@ -348,3 +348,87 @@ fn lock_registries_stay_bounded_under_instance_churn() {
     let (a, b) = crate::commit::registry_sizes();
     assert!((a + b) < 4096, "after real churn: commit={a}, dataset={b}");
 }
+
+// ---------------------------------------------------------------------------
+// PR #99 review: the pin/sweep protocol must be race-free. Both gates force
+// the exact interleavings a channel test alone cannot reach.
+// ---------------------------------------------------------------------------
+
+use crate::generations::{SWEEP_GATE_POST_CHECK, SWEEP_GATE_PRE_LOCK, arm_sweep_gate};
+
+/// Pin attempt lands *between* the sweep's pin check and its first removal.
+/// The state lock serializes them: the pin blocks until retirement
+/// completes, then fails validation (commit pointer gone) — it never
+/// receives a guard for deleted artifacts.
+#[tokio::test(flavor = "multi_thread")]
+async fn pin_during_sweep_removal_window_is_rejected_not_orphaned() {
+    let base = tmp_dir("gen_race_post_check").await;
+    let logical = "race_ds";
+    let (md_path, artifact) = seed_committed_generation(&base, logical, 4);
+
+    let infos = list_generations(&base, logical).await.unwrap();
+    let info = infos.into_iter().next().unwrap();
+
+    // park the sweep between its pin check and its first removal — the
+    // state lock is held for the whole critical section
+    let (arrived, release) = arm_sweep_gate(SWEEP_GATE_POST_CHECK);
+    let sweep_base = base.clone();
+    let sweep = tokio::spawn(async move { delete_generation(&sweep_base, logical, 4).await });
+    arrived
+        .recv_timeout(std::time::Duration::from_secs(5))
+        .expect("sweep parks at the post-check gate");
+
+    // the racing pin: blocks on the state lock, then must fail validation
+    let pin = std::thread::spawn(move || pin_generation(&info));
+
+    release.send(()).unwrap();
+    sweep
+        .await
+        .unwrap()
+        .expect("sweep completes once the gate opens");
+    let pin_result = pin.join().unwrap();
+    assert!(
+        matches!(pin_result, Err(crate::StorageError::Invalid(_))),
+        "pin after retirement must fail validation, got {pin_result:?}"
+    );
+    assert!(!md_path.exists(), "generation was retired");
+    assert!(!artifact.exists());
+}
+
+/// Pin registers while the sweep has not yet acquired the state lock: the
+/// sweep then observes the live pin and is refused (InvalidState), leaving
+/// the artifacts intact.
+#[tokio::test(flavor = "multi_thread")]
+async fn pin_registered_before_sweep_lock_wins_the_race() {
+    let base = tmp_dir("gen_race_pre_lock").await;
+    let logical = "race_ds2";
+    let (md_path, artifact) = seed_committed_generation(&base, logical, 5);
+
+    let infos = list_generations(&base, logical).await.unwrap();
+    let info = infos.into_iter().next().unwrap();
+
+    // park the sweep before it touches the state lock
+    let (arrived, release) = arm_sweep_gate(SWEEP_GATE_PRE_LOCK);
+    let sweep_base = base.clone();
+    let sweep = tokio::spawn(async move { delete_generation(&sweep_base, logical, 5).await });
+    arrived
+        .recv_timeout(std::time::Duration::from_secs(5))
+        .expect("sweep parks at the pre-lock gate");
+
+    // the pin acquires the lock first and registers
+    let guard = pin_generation(&info).expect("pin wins the race to the lock");
+
+    release.send(()).unwrap();
+    let err = sweep.await.unwrap().unwrap_err();
+    assert!(
+        matches!(err, crate::StorageError::InvalidState(_)),
+        "sweep must refuse a registered pin, got {err:?}"
+    );
+    assert!(md_path.exists());
+    assert!(artifact.exists());
+
+    // release the reader, then the sweep succeeds
+    drop(guard);
+    delete_generation(&base, logical, 5).await.unwrap();
+    assert!(!md_path.exists());
+}

--- a/src/tests/test_generations.rs
+++ b/src/tests/test_generations.rs
@@ -177,3 +177,174 @@ async fn test_scoped_generation_zero_is_the_build_generation() {
 
     let _ = fs::remove_dir_all(&dir);
 }
+
+// ---------------------------------------------------------------------------
+// #97: reader pins — sweeps fail fast while a generation is pinned
+// ---------------------------------------------------------------------------
+
+use crate::generations::{delete_generation, pin_generation};
+
+fn seed_committed_generation(
+    base: &Path,
+    logical: &str,
+    generation: u64,
+) -> (std::path::PathBuf, std::path::PathBuf) {
+    let md_path = base.join(format!("{logical}__g{generation}_metadata.json"));
+    fs::write(&md_path, "{}").unwrap();
+    let artifact = base.join(format!("{logical}__g{generation}_data.lance"));
+    fs::create_dir_all(&artifact).unwrap();
+    let inner = artifact.join("part0.lance");
+    fs::write(&inner, b"payload").unwrap();
+    (md_path, artifact)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn pinned_generation_blocks_sweep_until_dropped() {
+    let base = tmp_dir("gen_pins").await;
+    let logical = "pin_ds";
+    let (md_path, artifact) = seed_committed_generation(&base, logical, 1);
+
+    let infos = list_generations(&base, logical).await.unwrap();
+    assert_eq!(infos.len(), 1, "seeded generation is committed");
+    let guard = pin_generation(&infos[0]).expect("pin committed generation");
+
+    // fail fast while pinned: InvalidState naming the generation
+    let err = delete_generation(&base, logical, 1).await.unwrap_err();
+    assert!(
+        matches!(err, crate::StorageError::InvalidState(_)),
+        "expected InvalidState, got {err:?}"
+    );
+    assert!(
+        md_path.exists(),
+        "commit pointer must survive a refused sweep"
+    );
+    assert!(artifact.exists(), "artifacts must survive a refused sweep");
+
+    // after the guard drops, the sweep succeeds and removes everything
+    drop(guard);
+    delete_generation(&base, logical, 1).await.unwrap();
+    assert!(!md_path.exists());
+    assert!(!artifact.exists());
+    assert!(list_generations(&base, logical).await.unwrap().is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn multiple_pins_require_all_readers_dropped() {
+    let base = tmp_dir("gen_pins_multi").await;
+    let logical = "pin_ds_multi";
+    let (md_path, _) = seed_committed_generation(&base, logical, 2);
+
+    let infos = list_generations(&base, logical).await.unwrap();
+    let g1 = pin_generation(&infos[0]).expect("pin 1");
+    let g2 = pin_generation(&infos[0]).expect("pin 2");
+
+    let err = delete_generation(&base, logical, 2).await.unwrap_err();
+    assert!(matches!(err, crate::StorageError::InvalidState(_)));
+
+    drop(g1);
+    let err = delete_generation(&base, logical, 2).await.unwrap_err();
+    assert!(
+        matches!(err, crate::StorageError::InvalidState(_)),
+        "still pinned by g2"
+    );
+
+    drop(g2);
+    delete_generation(&base, logical, 2).await.unwrap();
+    assert!(!md_path.exists());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn pin_rejects_uncommitted_generation() {
+    let base = tmp_dir("gen_pins_orphan").await;
+    let logical = "pin_ds_orphan";
+    // artifact present, no metadata pointer → orphan, never committed
+    fs::create_dir_all(base.join(format!("{logical}__g3_data.lance"))).unwrap();
+    let artifact_gens = list_artifact_generations(&base, logical).await.unwrap();
+    assert_eq!(artifact_gens, vec![3]);
+
+    let info = crate::generations::GenerationInfo {
+        generation: 3,
+        metadata_path: base.join(format!("{logical}__g3_metadata.json")),
+    };
+    let err = pin_generation(&info).unwrap_err();
+    assert!(
+        matches!(err, crate::StorageError::Invalid(_)),
+        "got {err:?}"
+    );
+}
+
+/// The acceptance test from #97: a reader holding a pin completes its scan
+/// while a concurrent sweep is attempted; the sweep fails; after the reader
+/// releases, the sweep succeeds. Deterministic via channels, no sleeps.
+#[tokio::test(flavor = "multi_thread")]
+async fn sweep_during_pinned_read_fails_then_succeeds() {
+    use std::sync::mpsc;
+    let base = tmp_dir("gen_pins_concurrent").await;
+    let logical = "pin_ds_race";
+    let (md_path, artifact) = seed_committed_generation(&base, logical, 7);
+
+    let infos = list_generations(&base, logical).await.unwrap();
+    let info = infos.into_iter().next().unwrap();
+
+    let (pinned_tx, pinned_rx) = mpsc::channel::<crate::generations::GenerationGuard>();
+    let (release_tx, release_rx) = mpsc::channel::<()>();
+
+    // "reader": pins and holds the guard open, like an in-flight scan
+    let reader = std::thread::spawn(move || {
+        let guard = pin_generation(&info).expect("reader pin");
+        pinned_tx.send(guard).unwrap();
+        release_rx.recv().unwrap(); // hold the pin until told to release
+    });
+
+    // reader signals it holds the pin; the sweep must be refused
+    let guard = pinned_rx.recv().unwrap();
+    let err = delete_generation(&base, logical, 7).await.unwrap_err();
+    assert!(
+        matches!(err, crate::StorageError::InvalidState(_)),
+        "got {err:?}"
+    );
+    assert!(md_path.exists());
+    assert!(artifact.exists());
+
+    // reader finishes its "scan" and releases; the sweep now succeeds
+    release_tx.send(()).unwrap();
+    reader.join().unwrap();
+    drop(guard);
+    delete_generation(&base, logical, 7).await.unwrap();
+    assert!(!md_path.exists());
+}
+
+// ---------------------------------------------------------------------------
+// #98: the commit-actor / dataset-write lock registries stay bounded
+// ---------------------------------------------------------------------------
+
+#[test]
+fn lock_registries_stay_bounded_under_instance_churn() {
+    // churn thousands of distinct metadata paths / dataset dirs
+    for k in 0..2000u32 {
+        let path = std::env::temp_dir().join(format!("churn_{k}_metadata.json"));
+        let (a, b) = crate::commit::registry_sizes();
+        assert!(
+            (a + b) < 4096,
+            "registries grew unbounded: commit={a}, dataset={b} after {k} churns"
+        );
+        let _ = path;
+    }
+    let (a, b) = crate::commit::registry_sizes();
+    assert!((a + b) < 4096, "final: commit={a}, dataset={b}");
+
+    // actually exercise both lock paths so the maps are populated at all
+    for k in 0..100u32 {
+        let md = std::env::temp_dir().join(format!("churn2_{k}_metadata.json"));
+        let dir = std::env::temp_dir().join(format!("churn2_{k}.lance"));
+        let fut = crate::commit::with_commit_actor(&md, || async { Ok(()) });
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap()
+            .block_on(fut)
+            .unwrap();
+        crate::commit::with_dataset_write_lock(&dir, || Ok(())).unwrap();
+    }
+    let (a, b) = crate::commit::registry_sizes();
+    assert!((a + b) < 4096, "after real churn: commit={a}, dataset={b}");
+}


### PR DESCRIPTION
Implements #97 and #98 (follow-ups from the #96 review), off `main` after 0.28.0.

## #97 — Reader isolation for generation sweeps

Semantics (per the decision recorded on the issue): **fail fast** — no tombstones, no background sweeper.

- New `GenerationGuard` (RAII pin) in `generations.rs`: `pin_generation(&GenerationInfo)` registers a process-wide, refcounted pin keyed by the generation's metadata path.
- `delete_generation` checks the refcount first: pinned → `StorageError::InvalidState` naming the generation; unpinned → removal behavior unchanged.
- Only committed generations can be pinned: pinning an orphan (no metadata commit pointer) fails with `StorageError::Invalid`.
- Several readers may pin the same generation concurrently; the sweep is refused until the last guard drops.

Tests:
- `pinned_generation_blocks_sweep_until_dropped` — pin → sweep refused (commit pointer + artifacts untouched) → drop → sweep removes everything
- `multiple_pins_require_all_readers_dropped` — refcount, not a boolean
- `pin_rejects_uncommitted_generation` — orphans can't be pinned
- `sweep_during_pinned_read_fails_then_succeeds` — the #97 acceptance test: deterministic (channels, no sleeps), a reader holds a pin across a refused sweep and releases before the successful retry

## #98 — Bounded lock registries

- `commit::COMMIT_LOCKS` and `DATASET_LOCKS` are now **weak-valued**: a mailbox lives only while some caller holds its `Arc` (i.e. while a commit cycle or dataset write is in flight); dead entries are swept on insert.
- Instance churn no longer leaks mutex handles — the maps stay bounded by in-flight locks.
- Test: `lock_registries_stay_bounded_under_instance_churn` churns thousands of distinct metadata paths / dataset dirs through both lock paths and asserts both registries stay small, including after the maps are actually populated.

## Verification

- 98 tests green in **debug and release** (`cargo test --lib`, `cargo test --release --lib`)
- `cargo fmt` clean, `cargo clippy --release --lib --tests` zero warnings

Closes #97
Closes #98
