### PR TITLE
fix: public commit serialization, durable metadata publish, typed nnz=0 rejection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 0.51.0 (2026-09-02)
+
+Consumer-review follow-ups from the genefold-vd adoption line
+(genegraph-storage #100, #101, #102).
+
+**Added**
+
+- `commit::with_commit_actor` is public: downstream consumers running
+  their own metadata read-modify-write cycles serialize against the same
+  per-path in-process commit actor the `save_*` registry paths use
+  (#100).
+- Cross-process arbitration convention (#100): `commit::with_file_lock`
+  (advisory `flock`, hold scope = the closure, runs on the blocking
+  pool; typed `UnsupportedFormat` off unix) and
+  `commit::lock_file_for_metadata` (`{metadata-stem}.lock` next to the
+  metadata file). Contract documented in the `commit` module docs and
+  the README; `tests/api_public.rs` guards the public surface by
+  compiling the crate as an external consumer.
+
+**Changed**
+
+- `generations::write_json_atomic` fsyncs the parent directory after the
+  rename, and on a freshly created parent the new directory (and its
+  parent) as well, so the metadata commit pointer survives a post-rename
+  crash (#101). The directory-fsync helper moves from the lancefmt
+  writer to `generations::fsync_dir` as the shared discipline; bare
+  filenames (`parent() == ""`) resolve to `.` and keep working.
+- `StorageBackend::save_sparse` rejects `nnz=0` matrices early and typed
+  (`StorageError::Invalid` — "fully disconnected: adjacency nnz=0")
+  before the metadata commit cycle and any artifact write, so a
+  disconnected graph leaves no partial directory behind (#102). The
+  lancefmt writer's empty-batch guard remains as the format-layer
+  backstop.
+
 ## 0.26.0 (2026-09-02)
 
 Transactional generations: the durability layer for append-style writers

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "genegraph-storage"
-version = "0.28.0"
+version = "0.51.0"
 dependencies = [
  "approx 0.5.1",
  "arrow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,6 +728,7 @@ dependencies = [
  "env_logger",
  "futures",
  "lance-bitpacking",
+ "libc",
  "log",
  "ordered-float 5.5.0",
  "parquet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,4 +50,5 @@ libc = "0.2"
 rand = "0.9.2"
 rand_distr = "0.5.1"
 approx = "0.5.1"
+serde_json = "^1.0.150"
 tokio = { version = "1", features = ["macros", "rt-multi-thread" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "genegraph-storage"
-version = "0.28.0"
+version = "0.51.0"
 edition = "2024"
 description = "vector database: base Lance storage"
 authors = ["Lorenzo <tunedconsulting@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,11 @@ prost = "0.14"
 prost-types = "0.14"
 lance-bitpacking = "11.0.0"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 rand = "0.9.2"
 rand_distr = "0.5.1"
 approx = "0.5.1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread" ] }

--- a/README.md
+++ b/README.md
@@ -94,25 +94,30 @@ must use the same serialization. Two levels are public:
   file.
 - **Cross-process** — the commit actor is per-process only. Independent
   processes (e.g. separate CLI invocations) take an advisory lock file
-  around the whole cycle with `commit::with_file_lock`, resolved through
-  the blessed convention `commit::lock_file_for_metadata(metadata_path)`
-  (`{metadata-stem}.lock` next to the metadata file):
+  around the whole cycle, resolved through the blessed convention
+  `commit::lock_file_for_metadata(metadata_path)` (`{metadata-stem}.lock`
+  next to the metadata file). The composed recipe — file lock held across
+  the awaited actor cycle — is
+  `commit::with_metadata_file_lock(metadata_path, cycle)`:
 
 ```rust
-use genegraph_storage::commit::{lock_file_for_metadata, with_commit_actor, with_file_lock};
+use genegraph_storage::commit::with_metadata_file_lock;
 
 let metadata_path = std::path::Path::new("base/ds__g1_metadata.json");
-let lock_path = lock_file_for_metadata(&metadata_path);
-with_file_lock(&lock_path, || {
-    // serialized across processes; run your load → mutate → publish here
+with_metadata_file_lock(metadata_path, || async {
+    // load → mutate → publish here: serialized across processes *and*
+    // against in-process save_* cycles
     Ok(())
 })
 .await
 .unwrap();
 ```
 
-Every writer of a given metadata file must take the same lock file before
-mutating it — arbitration is only as strong as the convention.
+For consumers whose whole cycle is synchronous,
+`commit::with_file_lock` takes the same lock file around a sync closure —
+it serializes across processes but does not compose with the in-process
+actor. Every writer of a given metadata file must take the same lock file
+before mutating it — arbitration is only as strong as the convention.
 
 ## Lance format
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,19 @@ it serializes across processes but does not compose with the in-process
 actor. Every writer of a given metadata file must take the same lock file
 before mutating it — arbitration is only as strong as the convention.
 
+**Operational note.** The flock wait is unbounded and runs through
+`spawn_blocking`: a parked waiter cannot be aborted, and many long-lived
+waiters can exhaust the runtime's blocking-thread capacity. That is a
+sound trade for metadata commits *if* cycles stay short, contention is
+normally brief, nothing under the lock does lengthy compute/network I/O
+or waits indefinitely, and you understand shutdown behavior with a stuck
+holder (blocked `spawn_blocking` tasks are abandoned by
+`Runtime::shutdown_timeout`, awaited by `shutdown_background`; process
+exit always releases the flock). If waits could be prolonged or numerous,
+prefer a dedicated lock-management thread, an explicit timeout or
+cancellation strategy, or a storage system with transactional
+coordination.
+
 ## Lance format
 
 The default build runs the in-house Lance v2.1 implementation (`lancefmt`) for all `StorageBackend` I/O: manifest with inline Overwrite transactions, txn files, version hints, MiniBlock pages with Flat / InlineBitpacking / FixedSizeList value compression. Encodings outside the supported subset are rejected with `StorageError::UnsupportedFormat` (never guessed). Interop conformance is fixture-based: golden fixtures written by the official lance crate are read back by the in-house reader's suite.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,38 @@ Append-style writers get immutable, atomically-committed generations:
 let gen = storage.scoped_generation(1); // artifacts at {logical}__g1_{key}.lance
 ```
 
+### Concurrent writers and metadata safety
+
+Every `save_*` call runs its metadata registry update through a per-path
+commit actor, so concurrent tasks inside one process never lose updates.
+Downstream code that performs its **own** metadata read-modify-write cycles
+must use the same serialization. Two levels are public:
+
+- **In-process** — `commit::with_commit_actor(metadata_path, cycle)`
+  serializes your cycle against the registry paths of the same metadata
+  file.
+- **Cross-process** — the commit actor is per-process only. Independent
+  processes (e.g. separate CLI invocations) take an advisory lock file
+  around the whole cycle with `commit::with_file_lock`, resolved through
+  the blessed convention `commit::lock_file_for_metadata(metadata_path)`
+  (`{metadata-stem}.lock` next to the metadata file):
+
+```rust
+use genegraph_storage::commit::{lock_file_for_metadata, with_commit_actor, with_file_lock};
+
+let metadata_path = std::path::Path::new("base/ds__g1_metadata.json");
+let lock_path = lock_file_for_metadata(&metadata_path);
+with_file_lock(&lock_path, || {
+    // serialized across processes; run your load → mutate → publish here
+    Ok(())
+})
+.await
+.unwrap();
+```
+
+Every writer of a given metadata file must take the same lock file before
+mutating it — arbitration is only as strong as the convention.
+
 ## Lance format
 
 The default build runs the in-house Lance v2.1 implementation (`lancefmt`) for all `StorageBackend` I/O: manifest with inline Overwrite transactions, txn files, version hints, MiniBlock pages with Flat / InlineBitpacking / FixedSizeList value compression. Encodings outside the supported subset are rejected with `StorageError::UnsupportedFormat` (never guessed). Interop conformance is fixture-based: golden fixtures written by the official lance crate are read back by the in-house reader's suite.

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -54,30 +54,40 @@
 //!    });
 //!    ```
 //!
-//! 2. **Cross-process** — [`with_file_lock`], an advisory `flock` held for
-//!    the documented hold scope (the whole closure: lock → read-modify-write
-//!    → publish → release). The blessed convention is one lock file next to
-//!    the metadata file, named by [`lock_file_for_metadata`]
-//!    (`{metadata-stem}.lock`). Multi-process consumers (independent CLI
-//!    invocations) wrap the whole cycle — closure body *and* the
-//!    [`with_commit_actor`] call — in [`with_file_lock`]:
+//! 2. **Cross-process** — an advisory `flock` on a lock file, held for the
+//!    documented hold scope (the whole read-modify-write cycle: lock →
+//!    load → mutate → publish → release). The blessed convention is one
+//!    lock file next to the metadata file, named by
+//!    [`lock_file_for_metadata`] (`{metadata-stem}.lock`). Two forms
+//!    exist:
 //!
-//!    ```no_run
-//!    use std::path::Path;
-//!    use genegraph_storage::commit::{lock_file_for_metadata, with_file_lock};
+//!    - [`with_metadata_file_lock`] — the **composed** recipe: the file
+//!      lock is held across the whole awaited commit-actor cycle, so
+//!      cross-process exclusion *and* in-process actor serialization are
+//!      both active for the duration of the cycle. This is what
+//!      multi-process consumers whose metadata file is also touched by
+//!      async `save_*` paths must use:
 //!
-//!    futures::executor::block_on(async {
-//!        let metadata_path = Path::new("base/ds__g1_metadata.json");
-//!        let lock_path = lock_file_for_metadata(metadata_path);
-//!        let cycle = with_file_lock(&lock_path, || {
-//!            // serialized across processes; hand in-process cycles to the
-//!            // commit actor inside (blocking context, no async here)
-//!            Ok(())
-//!        })
-//!        .await;
-//!        let _ = cycle;
-//!    });
-//!    ```
+//!      ```no_run
+//!      use std::path::Path;
+//!      use genegraph_storage::commit::with_metadata_file_lock;
+//!
+//!      futures::executor::block_on(async {
+//!          let metadata_path = Path::new("base/ds__g1_metadata.json");
+//!          let cycle = with_metadata_file_lock(metadata_path, || async {
+//!              // load → mutate → publish (via generations::write_json_atomic)
+//!              Ok(())
+//!          })
+//!          .await;
+//!          let _ = cycle;
+//!      });
+//!      ```
+//!
+//!    - [`with_file_lock`] — the raw lock for consumers whose whole cycle
+//!      is **synchronous**. Its closure runs on the blocking pool and
+//!      cannot await the commit actor; it therefore does *not* serialize
+//!      against in-process async `save_*` cycles. If that matters, use
+//!      [`with_metadata_file_lock`].
 //!
 //! The lock file is a rendezvous point for cooperating writers, not a
 //! commit artifact: it carries no data and is left in place after release.
@@ -169,10 +179,11 @@ where
 ///
 /// The closure is synchronous and runs on the blocking pool: the flock can
 /// block arbitrarily long on a competing holder, so it must never run on
-/// an async executor thread. In-process cycle serialization stays with
-/// [`with_commit_actor`]; the two compose (actor cycle *inside* the file
-/// lock). Off unix this fails with
-/// [`StorageError::UnsupportedFormat`] rather than silently skipping
+/// an async executor thread. Because the closure is sync, it **cannot**
+/// await [`with_commit_actor`] — a cycle run here is serialized across
+/// processes but not against in-process async `save_*` cycles; use
+/// [`with_metadata_file_lock`] when both are required. Off unix this fails
+/// with [`StorageError::UnsupportedFormat`] rather than silently skipping
 /// arbitration.
 pub async fn with_file_lock<T, F>(lock_path: &Path, f: F) -> StorageResult<T>
 where
@@ -262,6 +273,37 @@ impl FileLock {
             "cross-process file locking (with_file_lock) requires a POSIX platform".into(),
         ))
     }
+}
+
+/// The blessed recipe for a multi-process consumer's metadata
+/// read-modify-write cycle (#100, review composition fix): the advisory
+/// file lock ([`lock_file_for_metadata`]) is held across the **whole**
+/// awaited commit-actor cycle — cross-process exclusion and in-process
+/// actor serialization are both active for the duration of `cycle`.
+///
+/// The closure is async: a full load → mutate → publish cycle (including
+/// any `save_*`-style actor work) runs inside, while independent processes
+/// taking the same lock file serialize behind it. Lock acquisition runs on
+/// the blocking pool (the flock can park on a competing holder); the lock
+/// is released when the cycle's future completes.
+///
+/// For consumers whose RMW is entirely synchronous, [`with_file_lock`]
+/// wraps the same lock file — but a sync closure cannot await the commit
+/// actor; only this helper composes the two locks.
+pub async fn with_metadata_file_lock<T, F, Fut>(
+    metadata_path: &Path,
+    cycle: F,
+) -> StorageResult<T>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = StorageResult<T>>,
+{
+    let lock_path = lock_file_for_metadata(metadata_path);
+    let lock_path2 = lock_path.clone();
+    let _lock = tokio::task::spawn_blocking(move || FileLock::acquire(&lock_path2))
+        .await
+        .map_err(|e| StorageError::Io(format!("file lock task failed: {e}")))??;
+    with_commit_actor(metadata_path, cycle).await
 }
 
 /// Runs `write` under the dataset's write mailbox. `write` must be a

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -26,11 +26,66 @@
 //! sequence inside the lancefmt writer for data/txn/manifest files):
 //! readers never observe a half-written commit pointer, and a read after a
 //! completed commit observes its effects (read-your-own-writes).
-//! Cross-process arbitration stays with the transactional-generations work
-//! (#93/#81-P5).
+//!
+//! # Downstream contract (#100)
+//!
+//! The commit actor is an **in-process** mailbox: it serializes concurrent
+//! tasks inside one process, never two independent processes. Two levels of
+//! arbitration are exposed:
+//!
+//! 1. **In-process** — [`with_commit_actor`] wraps a full metadata
+//!    read-modify-write cycle (load → mutate → publish). Every cycle over a
+//!    given metadata file runs under the same per-path mailbox, so cycles
+//!    from your code and cycles from the `save_*` registry paths cannot
+//!    interleave and lose updates:
+//!
+//!    ```no_run
+//!    use std::path::Path;
+//!    use genegraph_storage::commit::with_commit_actor;
+//!
+//!    futures::executor::block_on(async {
+//!        let metadata_path = Path::new("base/ds__g1_metadata.json");
+//!        let cycle: genegraph_storage::StorageResult<()> = with_commit_actor(metadata_path, || async {
+//!            // load → mutate → publish (via generations::write_json_atomic)
+//!            Ok(())
+//!        })
+//!        .await;
+//!        let _ = cycle;
+//!    });
+//!    ```
+//!
+//! 2. **Cross-process** — [`with_file_lock`], an advisory `flock` held for
+//!    the documented hold scope (the whole closure: lock → read-modify-write
+//!    → publish → release). The blessed convention is one lock file next to
+//!    the metadata file, named by [`lock_file_for_metadata`]
+//!    (`{metadata-stem}.lock`). Multi-process consumers (independent CLI
+//!    invocations) wrap the whole cycle — closure body *and* the
+//!    [`with_commit_actor`] call — in [`with_file_lock`]:
+//!
+//!    ```no_run
+//!    use std::path::Path;
+//!    use genegraph_storage::commit::{lock_file_for_metadata, with_file_lock};
+//!
+//!    futures::executor::block_on(async {
+//!        let metadata_path = Path::new("base/ds__g1_metadata.json");
+//!        let lock_path = lock_file_for_metadata(metadata_path);
+//!        let cycle = with_file_lock(&lock_path, || {
+//!            // serialized across processes; hand in-process cycles to the
+//!            // commit actor inside (blocking context, no async here)
+//!            Ok(())
+//!        })
+//!        .await;
+//!        let _ = cycle;
+//!    });
+//!    ```
+//!
+//! The lock file is a rendezvous point for cooperating writers, not a
+//! commit artifact: it carries no data and is left in place after release.
+//! Arbitration is only as strong as the convention — every writer of the
+//! same metadata file must take the same lock file before mutating it.
 
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex as StdMutex, OnceLock, Weak};
 
 use tokio::sync::Mutex;
@@ -77,9 +132,17 @@ fn dataset_lock_for(dataset_dir: &Path) -> Arc<StdMutex<()>> {
 }
 
 /// Runs `commit` (a full metadata read-modify-write cycle) under the
-/// instance's commit actor: at most one cycle runs at a time for the same
-/// metadata path.
-pub(crate) async fn with_commit_actor<T, F, Fut>(
+/// metadata path's commit actor: at most one cycle runs at a time for the
+/// same path **within this process**.
+///
+/// Public for downstream consumers (#100): any code that performs its own
+/// load → mutate → publish cycle over a metadata file outside the `save_*`
+/// registry paths routes the whole cycle through this function with the
+/// same `metadata_path` the storage instance uses, so cycles from both
+/// sides are serialized against each other. Cross-process arbitration is a
+/// separate concern — wrap the cycle in [`with_file_lock`] (see the module
+/// docs for the recipe).
+pub async fn with_commit_actor<T, F, Fut>(
     metadata_path: &Path,
     commit: F,
 ) -> StorageResult<T>
@@ -90,6 +153,115 @@ where
     let mailbox = lock_for(metadata_path);
     let _guard = mailbox.lock().await;
     commit().await
+}
+
+/// Cross-process commit arbitration (#100): an advisory `flock` on
+/// `lock_path`, held for the closure's scope — lock → read-modify-write →
+/// publish → release. Independent processes (e.g. separate CLI
+/// invocations) that take the same lock file cannot interleave their
+/// metadata cycles.
+///
+/// The blessed lock-file location for a metadata file is
+/// [`lock_file_for_metadata`] (`{metadata-stem}.lock` next to the file);
+/// the lock file is created on demand (missing parent directories
+/// included) and left in place after release — it is a rendezvous point,
+/// not a commit artifact.
+///
+/// The closure is synchronous and runs on the blocking pool: the flock can
+/// block arbitrarily long on a competing holder, so it must never run on
+/// an async executor thread. In-process cycle serialization stays with
+/// [`with_commit_actor`]; the two compose (actor cycle *inside* the file
+/// lock). Off unix this fails with
+/// [`StorageError::UnsupportedFormat`] rather than silently skipping
+/// arbitration.
+pub async fn with_file_lock<T, F>(lock_path: &Path, f: F) -> StorageResult<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> StorageResult<T> + Send + 'static,
+{
+    let lock_path = lock_path.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        let _lock = FileLock::acquire(&lock_path)?;
+        f()
+    })
+    .await
+    .map_err(|e| StorageError::Io(format!("file lock task failed: {e}")))?
+}
+
+/// The blessed lock-file path for a metadata file (#100):
+/// `{metadata-stem}.lock` next to it — `ds__g1_metadata.json` locks through
+/// `ds__g1_metadata.lock`. All cooperating writers of the same metadata
+/// file must resolve the lock through this function so the convention
+/// holds.
+pub fn lock_file_for_metadata(metadata_path: &Path) -> PathBuf {
+    match metadata_path.file_stem() {
+        Some(stem) => metadata_path.with_file_name(format!("{}.lock", stem.to_string_lossy())),
+        None => metadata_path.with_file_name(format!(
+            "{}.lock",
+            metadata_path.as_os_str().to_string_lossy()
+        )),
+    }
+}
+
+/// RAII advisory lock (unix `flock(2)`, exclusive). The lock is held by the
+/// open file description, so two `acquire` calls — in this process or
+/// another — exclude each other until the guard drops (explicit `LOCK_UN`,
+/// and again on close).
+#[cfg(unix)]
+struct FileLock(std::fs::File);
+
+#[cfg(unix)]
+impl FileLock {
+    fn acquire(lock_path: &Path) -> StorageResult<Self> {
+        use std::os::unix::io::AsRawFd;
+
+        if let Some(parent) = lock_path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| StorageError::Io(format!("create lock parent {parent:?}: {e}")))?;
+        }
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(lock_path)
+            .map_err(|e| StorageError::Io(format!("open lock {lock_path:?}: {e}")))?;
+        // SAFETY: fd is valid; flock(2) has no preconditions beyond it.
+        let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+        if rc != 0 {
+            return Err(StorageError::Io(format!(
+                "flock {lock_path:?}: {}",
+                std::io::Error::last_os_error()
+            )));
+        }
+        Ok(FileLock(file))
+    }
+}
+
+#[cfg(unix)]
+impl Drop for FileLock {
+    fn drop(&mut self) {
+        use std::os::unix::io::AsRawFd;
+
+        // SAFETY: fd is still owned by self; the lock is released here and
+        // again (idempotently) when the file closes.
+        unsafe { libc::flock(self.0.as_raw_fd(), libc::LOCK_UN) };
+    }
+}
+
+/// Off unix there is no blessed arbitration primitive; fail typed instead
+/// of silently skipping cross-process serialization (#100).
+#[cfg(not(unix))]
+struct FileLock;
+
+#[cfg(not(unix))]
+impl FileLock {
+    fn acquire(_lock_path: &Path) -> StorageResult<Self> {
+        Err(StorageError::UnsupportedFormat(
+            "cross-process file locking (with_file_lock) requires a POSIX platform".into(),
+        ))
+    }
 }
 
 /// Runs `write` under the dataset's write mailbox. `write` must be a

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -93,6 +93,10 @@
 //! commit artifact: it carries no data and is left in place after release.
 //! Arbitration is only as strong as the convention — every writer of the
 //! same metadata file must take the same lock file before mutating it.
+//!
+//! Both lock forms wait on the blocking pool; see the operational caution
+//! on [`with_metadata_file_lock`] for the assumptions this puts on commit
+//! cycles and what to prefer when waits could be prolonged or numerous.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -185,6 +189,10 @@ where
 /// [`with_metadata_file_lock`] when both are required. Off unix this fails
 /// with [`StorageError::UnsupportedFormat`] rather than silently skipping
 /// arbitration.
+///
+/// The blocking-pool caveats documented on [`with_metadata_file_lock`]
+/// apply here identically: unbounded waits, non-abortable waiters,
+/// blocking-thread capacity.
 pub async fn with_file_lock<T, F>(lock_path: &Path, f: F) -> StorageResult<T>
 where
     T: Send + 'static,
@@ -290,6 +298,32 @@ impl FileLock {
 /// For consumers whose RMW is entirely synchronous, [`with_file_lock`]
 /// wraps the same lock file — but a sync closure cannot await the commit
 /// actor; only this helper composes the two locks.
+///
+/// # Operational caution (blocking-pool waits)
+///
+/// The flock wait is unbounded and runs through `spawn_blocking`, which
+/// Tokio documents for blocking work that is bounded and eventually
+/// completes: a waiter that has already parked cannot be reliably
+/// aborted, and many long-lived blocked waiters can exhaust the runtime's
+/// blocking-thread capacity. This design is reasonable for metadata
+/// commits when:
+///
+/// - commit cycles are short — the hold scope is a JSON load → mutate →
+///   publish, not compute;
+/// - contention is normally brief;
+/// - callers do not hold the lock across lengthy compute, network I/O,
+///   user interaction, or indefinite waits;
+/// - shutdown behavior with a stuck lock holder is understood: blocked
+///   `spawn_blocking` tasks are not aborted by task cancellation;
+///   [`tokio::runtime::Runtime::shutdown_timeout`] abandons them after a
+///   grace period while [`tokio::runtime::Runtime::shutdown_background`]
+///   waits them out — and process exit always closes the descriptor,
+///   releasing the flock.
+///
+/// If lock waits could be prolonged or numerous, prefer a dedicated
+/// lock-management thread, an explicit timeout/cancellation strategy
+/// (bounded wait before acquisition), or a storage system with
+/// transactional coordination over unbounded `flock` waits here.
 pub async fn with_metadata_file_lock<T, F, Fut>(
     metadata_path: &Path,
     cycle: F,

--- a/src/generations.rs
+++ b/src/generations.rs
@@ -253,21 +253,42 @@ pub fn pin_generation(info: &GenerationInfo) -> StorageResult<GenerationGuard> {
 }
 
 /// Atomic JSON publish: write to a unique `{path}.tmp`, fsync, rename over
-/// `path`.
+/// `path`, then fsync the parent directory (#101).
 ///
 /// The rename is the single commit point (POSIX-atomic within a directory):
 /// concurrent readers observe either the previous file or the complete new
-/// one, never a truncated write. This is the ONLY sanctioned way to publish
-/// a metadata file. The tmp name is uuid-unique (#95) so concurrent
-/// publishers of the same path cannot corrupt each other's staging file;
-/// the last rename wins, which makes last-writer-wins explicit instead of
-/// interleaved.
+/// one, never a truncated write. The post-rename directory fsync makes the
+/// rename itself durable — without it, a crash can revert the metadata
+/// commit pointer (the single atomic commit of a generation, #93) to the
+/// previous generation, or lose it entirely on a first commit.
+///
+/// This is the ONLY sanctioned way to publish a metadata file. The tmp name
+/// is uuid-unique (#95) so concurrent publishers of the same path cannot
+/// corrupt each other's staging file; the last rename wins, which makes
+/// last-writer-wins explicit instead of interleaved.
 pub fn write_json_atomic(path: &Path, contents: &str) -> StorageResult<()> {
     use std::io::Write;
 
     let tmp = path.with_extension(format!("json.tmp.{}", uuid::Uuid::new_v4().simple()));
-    if let Some(parent) = path.parent() {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    // `parent()` yields "" for bare filenames; resolve it to the working
+    // directory so the fsync discipline below has a real handle to sync.
+    let parent = if parent.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        parent
+    };
+    if !parent.exists() {
         std::fs::create_dir_all(parent).map_err(|e| StorageError::Io(e.to_string()))?;
+        // The fresh directory itself must be durable before anything is
+        // published inside it: fsync it and its parent so both directory
+        // entries survive a crash (#101).
+        if let Some(grandparent) = parent.parent()
+            && !grandparent.as_os_str().is_empty()
+        {
+            fsync_dir(grandparent)?;
+        }
+        fsync_dir(parent)?;
     }
     {
         let mut f = std::fs::File::create(&tmp).map_err(|e| StorageError::Io(e.to_string()))?;
@@ -276,6 +297,21 @@ pub fn write_json_atomic(path: &Path, contents: &str) -> StorageResult<()> {
         f.sync_all().map_err(|e| StorageError::Io(e.to_string()))?;
     }
     std::fs::rename(&tmp, path).map_err(|e| StorageError::Io(e.to_string()))?;
+    fsync_dir(parent)
+}
+
+/// fsyncs a directory so a completed rename is itself durable
+/// (directory-entry durability, #101 / lancefmt #95-3). No-op off unix.
+pub(crate) fn fsync_dir(dir: &Path) -> StorageResult<()> {
+    #[cfg(unix)]
+    {
+        let f = std::fs::File::open(dir)
+            .map_err(|e| StorageError::Io(format!("open dir {dir:?} for fsync: {e}")))?;
+        f.sync_all()
+            .map_err(|e| StorageError::Io(format!("fsync dir {dir:?}: {e}")))?;
+    }
+    #[cfg(not(unix))]
+    let _ = dir;
     Ok(())
 }
 

--- a/src/lance_storage_graph.rs
+++ b/src/lance_storage_graph.rs
@@ -467,6 +467,19 @@ impl StorageBackend for LanceStorageGraph {
         md_path: &Path,
     ) -> StorageResult<()> {
         self.validate_initialized(md_path)?;
+        // #102, fail early and typed: an nnz=0 sparse matrix (a fully
+        // disconnected adjacency — a legitimate data state, e.g. from a
+        // too-small eps) cannot be persisted as a sparse artifact. Reject
+        // here, before the metadata commit cycle and before any artifact
+        // write, so no partial directory is left behind.
+        if matrix.nnz() == 0 {
+            return Err(StorageError::Invalid(format!(
+                "sparse '{key}' is fully disconnected: adjacency nnz=0 ({}x{}) — \
+                 raise --eps/--k or gate the input before persisting",
+                matrix.rows(),
+                matrix.cols()
+            )));
+        }
         let path = self.file_path(key);
         info!(
             "Saving sparse {} matrix: {} x {}, nnz={} at {:?}",

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,6 +1,7 @@
 mod lancefmt_common;
 mod test_catalog;
 mod test_collections;
+mod test_commit;
 mod test_data;
 mod test_generations;
 mod test_lance_layer;

--- a/src/tests/test_commit.rs
+++ b/src/tests/test_commit.rs
@@ -9,7 +9,9 @@ use std::sync::mpsc;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::time::Duration;
 
-use crate::commit::{lock_file_for_metadata, with_commit_actor, with_file_lock};
+use crate::commit::{
+    lock_file_for_metadata, with_commit_actor, with_file_lock, with_metadata_file_lock,
+};
 use crate::generations::write_json_atomic;
 
 use super::tmp_dir;
@@ -78,6 +80,100 @@ fn lock_file_convention_is_stem_dot_lock() {
         lock_file_for_metadata(Path::new("/base/registry")),
         PathBuf::from("/base/registry.lock")
     );
+}
+
+/// The composed helper (review feedback on #100) holds the advisory file
+/// lock across the whole awaited actor cycle: while a cycle is parked
+/// mid-RMW, another process-shaped lock holder stays excluded, and
+/// concurrent cycles on the same metadata file serialize (both increments
+/// land).
+#[tokio::test(flavor = "multi_thread")]
+async fn metadata_file_lock_holds_flock_across_the_actor_cycle() {
+    let base = tmp_dir("composed_lock_cycle").await;
+    let md = base.join("ds__g1_metadata.json");
+    write_json_atomic(&md, "0").unwrap();
+
+    // Park the composed cycle mid-RMW; a foreign flock holder must stay
+    // excluded until the cycle completes.
+    let (entered_tx, entered_rx) = mpsc::channel::<()>();
+    let (release_tx, release_rx) = mpsc::channel::<()>();
+    let md_a = md.clone();
+    let md_a_ref = md_a.clone();
+    let cycle_a = tokio::spawn(async move {
+        with_metadata_file_lock(&md_a_ref, move || async move {
+            entered_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+            let n: u8 = std::fs::read_to_string(&md_a).unwrap().trim().parse().unwrap();
+            write_json_atomic(&md_a, &(n + 1).to_string()).unwrap();
+            Ok(())
+        })
+        .await
+        .unwrap();
+    });
+    entered_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("composed cycle must start");
+
+    let (entered_b_tx, entered_b_rx) = mpsc::channel::<()>();
+    let lock_b = lock_file_for_metadata(&md);
+    let holder_b = std::thread::spawn(move || {
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap()
+            .block_on(async {
+                with_file_lock(&lock_b, move || {
+                    entered_b_tx.send(()).unwrap();
+                    Ok(())
+                })
+                .await
+                .unwrap()
+            })
+    });
+    assert!(
+        entered_b_rx.recv_timeout(Duration::from_millis(300)).is_err(),
+        "the flock must be held across the awaited cycle"
+    );
+
+    // Release; the cycle completes its write and the waiter enters.
+    release_tx.send(()).unwrap();
+    cycle_a.await.unwrap();
+    entered_b_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("waiter must acquire after the cycle releases");
+    holder_b.join().unwrap();
+
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+/// Two concurrent composed cycles on the same metadata file serialize end
+/// to end — flock first, then actor — so both increments land.
+#[tokio::test(flavor = "multi_thread")]
+async fn metadata_file_lock_serializes_concurrent_cycles() {
+    let base = tmp_dir("composed_lock_concurrent").await;
+    let md = base.join("ds__g1_metadata.json");
+    write_json_atomic(&md, "0").unwrap();
+
+    let run = |md: PathBuf| async move {
+        let md_inner = md.clone();
+        with_metadata_file_lock(&md, move || async move {
+            let n: u8 = std::fs::read_to_string(&md_inner)
+                .unwrap()
+                .trim()
+                .parse()
+                .unwrap();
+            write_json_atomic(&md_inner, &(n + 1).to_string()).unwrap();
+            Ok(())
+        })
+        .await
+        .unwrap();
+    };
+    let (ra, rb) = tokio::join!(run(md.clone()), run(md.clone()));
+    let _ = (ra, rb);
+
+    let final_count: u8 = std::fs::read_to_string(&md).unwrap().trim().parse().unwrap();
+    assert_eq!(final_count, 2, "concurrent composed cycles must not lose updates");
+
+    let _ = std::fs::remove_dir_all(&base);
 }
 
 use std::path::Path;

--- a/src/tests/test_commit.rs
+++ b/src/tests/test_commit.rs
@@ -1,0 +1,171 @@
+//! #100: commit serialization exposed to downstream consumers.
+//!
+//! Consumers that run their **own** metadata read-modify-write cycles (outside
+//! the `save_*` registry paths) must reach the same serialization the internal
+//! registry paths use, plus a blessed cross-process arbitration convention.
+
+use std::path::PathBuf;
+use std::sync::mpsc;
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::time::Duration;
+
+use crate::commit::{lock_file_for_metadata, with_commit_actor, with_file_lock};
+use crate::generations::write_json_atomic;
+
+use super::tmp_dir;
+
+/// Two concurrent metadata read-modify-write cycles on the same path (the
+/// shape every downstream consumer's own registry write takes) are
+/// serialized by the commit actor: the second cycle observes the first's
+/// write, so no update is lost.
+#[tokio::test(flavor = "multi_thread")]
+async fn commit_actor_serializes_concurrent_read_modify_write_cycles() {
+    let dir = tmp_dir("commit_actor_no_lost_update").await;
+    let md = dir.join("ds__g1_metadata.json");
+    write_json_atomic(&md, "0").unwrap();
+
+    // Each cycle reads a shared counter, then publishes counter+1. Each
+    // cycle's observation is recorded in its own atomic: under
+    // serialization the second cycle must see the first's write; interleaved,
+    // both would see 0.
+    let seen_a = std::sync::Arc::new(AtomicU8::new(0));
+    let seen_b = std::sync::Arc::new(AtomicU8::new(0));
+    let md_a = md.clone();
+    let md_a_ref = md_a.clone();
+    let seen_a_for_a = seen_a.clone();
+    let a = with_commit_actor(&md_a_ref, move || async move {
+        let n: u8 = std::fs::read_to_string(&md_a).unwrap().trim().parse().unwrap();
+        seen_a_for_a.store(n + 1, Ordering::SeqCst);
+        write_json_atomic(&md_a, &(n + 1).to_string()).unwrap();
+        Ok(())
+    });
+    let md_b = md.clone();
+    let md_b_ref = md_b.clone();
+    let seen_b_for_b = seen_b.clone();
+    let b = with_commit_actor(&md_b_ref, move || async move {
+        let n: u8 = std::fs::read_to_string(&md_b).unwrap().trim().parse().unwrap();
+        seen_b_for_b.store(n + 11, Ordering::SeqCst);
+        write_json_atomic(&md_b, &(n + 1).to_string()).unwrap();
+        Ok(())
+    });
+    let (ra, rb) = tokio::join!(a, b);
+    ra.unwrap();
+    rb.unwrap();
+
+    // Valid orders: A first (a saw 0 -> 1, b saw A's write -> 12) or B
+    // first (b saw 0 -> 11, a saw B's write -> 2). An interleaved (lost
+    // update) pair would surface as both cycles observing 0: (1, 11).
+    let a_seen = seen_a.load(Ordering::SeqCst);
+    let b_seen = seen_b.load(Ordering::SeqCst);
+    assert!(
+        (a_seen, b_seen) == (1, 12) || (a_seen, b_seen) == (2, 11),
+        "cycles must observe strictly ordered states, got a={a_seen}, b={b_seen}"
+    );
+    let final_count: u8 = std::fs::read_to_string(&md).unwrap().trim().parse().unwrap();
+    assert_eq!(final_count, 2, "concurrent RMW cycles must not lose updates");
+}
+
+/// The blessed cross-process convention: `{metadata-stem}.lock` next to the
+/// metadata file.
+#[test]
+fn lock_file_convention_is_stem_dot_lock() {
+    assert_eq!(
+        lock_file_for_metadata(Path::new("/base/ds__g1_metadata.json")),
+        PathBuf::from("/base/ds__g1_metadata.lock")
+    );
+    // no extension: the full name is the stem
+    assert_eq!(
+        lock_file_for_metadata(Path::new("/base/registry")),
+        PathBuf::from("/base/registry.lock")
+    );
+}
+
+use std::path::Path;
+
+/// #100: the advisory file lock is a real cross-process arbitration
+/// primitive — a second holder (here: a second thread, its own flock open
+/// file description, exactly what another process would see) is excluded
+/// until the first releases, and the lock file is created on demand.
+#[test]
+fn file_lock_excludes_second_holder_until_released() {
+    let base = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap()
+        .block_on(tmp_dir("file_lock_exclusion"));
+    let lock = base.join("ds__g1_metadata.lock");
+
+    let (arrived_tx, arrived_rx) = mpsc::channel::<()>();
+    let (release_tx, release_rx) = mpsc::channel::<()>();
+    let lock_a = lock.clone();
+    let a = std::thread::spawn(move || {
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap()
+            .block_on(async {
+                with_file_lock(&lock_a, move || {
+                    arrived_tx.send(()).unwrap();
+                    // hold the lock until the test releases it
+                    release_rx.recv().unwrap();
+                    Ok("first")
+                })
+                .await
+                .unwrap()
+            })
+    });
+    arrived_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("first holder must acquire the lock");
+
+    // The second holder must stay excluded while the first holds the lock.
+    let (entered_tx, entered_rx) = mpsc::channel::<()>();
+    let lock_b = lock.clone();
+    let b = std::thread::spawn(move || {
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap()
+            .block_on(async {
+                with_file_lock(&lock_b, move || {
+                    entered_tx.send(()).unwrap();
+                    Ok(())
+                })
+                .await
+                .unwrap()
+            })
+    });
+    assert!(
+        entered_rx.recv_timeout(Duration::from_millis(300)).is_err(),
+        "second holder must block while the first holds the lock"
+    );
+
+    // Release; the waiter proceeds.
+    release_tx.send(()).unwrap();
+    assert_eq!(a.join().unwrap(), "first", "first holder completes");
+    entered_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("second holder must acquire after release");
+    b.join().unwrap();
+
+    // The lock file is created on demand and left in place (it is the
+    // rendezvous point, not a commit artifact).
+    assert!(lock.is_file(), "lock file must exist at {lock:?}");
+
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+/// The lock file's parent directory is created on demand, so a consumer can
+/// take the lock before creating the dataset directory itself.
+#[test]
+fn file_lock_creates_missing_parent_dirs() {
+    let base = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap()
+        .block_on(tmp_dir("file_lock_fresh_parent"));
+    let lock = base.join("fresh").join("nested").join("ds.lock");
+    tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap()
+        .block_on(async { with_file_lock(&lock, || Ok(())).await })
+        .unwrap();
+    assert!(lock.is_file());
+    let _ = std::fs::remove_dir_all(&base);
+}

--- a/src/tests/test_generations.rs
+++ b/src/tests/test_generations.rs
@@ -63,6 +63,62 @@ async fn test_write_json_atomic_overwrites_completely() {
     let _ = fs::remove_dir_all(&dir);
 }
 
+/// #101: the directory-fsync helper lives in one shared place so both the
+/// metadata commit pointer (`write_json_atomic`) and the lancefmt writer
+/// publish sequence use the same discipline. It must succeed on a real
+/// directory (its result is what makes a completed rename durable).
+#[test]
+fn fsync_dir_succeeds_on_real_directory() {
+    let dir = std::env::temp_dir().join(format!(
+        "gen_fsync_dir_probe_{}",
+        uuid::Uuid::new_v4().simple()
+    ));
+    fs::create_dir_all(&dir).unwrap();
+    crate::generations::fsync_dir(&dir).expect("fsync on a real directory must succeed");
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// #101: the commit pointer must survive a crash that happens right after
+/// the rename — the parent directory is fsynced after the rename so the
+/// directory entry itself is durable. Writes into a fresh (nested) parent
+/// directory exercise the create_dir_all + fsync path end to end.
+#[tokio::test(flavor = "multi_thread")]
+async fn write_json_atomic_publishes_into_fresh_parent_dir() {
+    let dir = tmp_dir("write_json_atomic_fresh_parent").await;
+    let path = dir.join("nested").join("deeper").join("ds__g1_metadata.json");
+
+    write_json_atomic(&path, r#"{"v": 1}"#).expect("publish into fresh parent dirs must succeed");
+    assert_eq!(fs::read_to_string(&path).unwrap(), r#"{"v": 1}"#);
+
+    // a second publish (rename over an existing entry) also stays intact
+    write_json_atomic(&path, r#"{"v": 2}"#).expect("republish must succeed");
+    assert_eq!(fs::read_to_string(&path).unwrap(), r#"{"v": 2}"#);
+
+    let residue: Vec<_> = fs::read_dir(path.parent().unwrap())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|x| x == "tmp"))
+        .collect();
+    assert!(residue.is_empty(), "tmp files must not leak: {residue:?}");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// #101 edge: a bare filename has `parent() == Some("")` (no directory
+/// component). The parent-fsync discipline must not turn that previously
+/// working shape into an error — the empty path resolves to the process
+/// working directory.
+#[test]
+fn write_json_atomic_accepts_bare_filename_without_parent() {
+    let name = format!("bare_{}_metadata.json", uuid::Uuid::new_v4().simple());
+    let cwd = std::env::current_dir().unwrap();
+    write_json_atomic(Path::new(&name), r#"{"bare": true}"#)
+        .expect("bare-filename publish must keep working");
+    let contents = fs::read_to_string(cwd.join(&name)).unwrap();
+    assert_eq!(contents, r#"{"bare": true}"#);
+    let _ = fs::remove_file(cwd.join(&name));
+}
+
 /// Only generations with a metadata file are committed/listed; artifact
 /// generations without one (orphans from a pre-commit crash) are visible
 /// to the sweep API but never to resolution.

--- a/src/tests/test_lance_layer.rs
+++ b/src/tests/test_lance_layer.rs
@@ -244,6 +244,52 @@ async fn test_lance_sparse_roundtrip() {
     assert_eq!(adjacency, loaded);
 }
 
+/// #102 (fail early and typed): a fully disconnected graph (adjacency
+/// nnz=0) is a legitimate data state that the sparse artifact path cannot
+/// persist. It must be rejected at save time — before the metadata
+/// read-modify-write cycle and before any artifact write — so no partial
+/// directory is left behind and the consumer gets an actionable error.
+#[tokio::test(flavor = "multi_thread")]
+async fn save_sparse_rejects_disconnected_nnz_zero_matrix_before_writes() {
+    crate::tests::init();
+    let name = "sparse_nnz0_rejected";
+    let (_, storage, data, _, _) = init_test_builder(name).await;
+    let (nitems, nfeatures) = data.shape();
+
+    let md = GeneMetadata::seed_metadata(name, nitems, nfeatures, &storage)
+        .await
+        .unwrap();
+    let md_path: PathBuf = storage.save_metadata(&md).await.unwrap();
+
+    // 8x8 fully disconnected adjacency: nnz=0 with declared shape, exactly
+    // the lambda-graph state a too-small eps produces.
+    let adjacency = CsMat::zero((8, 8));
+    let err = storage
+        .save_sparse("adjacency", &adjacency, &md_path)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, StorageError::Invalid(ref m) if m.contains("nnz=0") && m.contains("disconnected")),
+        "expected typed disconnected-graph validation error, got {err:?}"
+    );
+
+    // fail-early contract: the registry commit must not have happened —
+    // the metadata still has no adjacency entry.
+    let md_after = storage.load_metadata().await.unwrap();
+    assert!(
+        !md_after.files.contains_key("adjacency"),
+        "a rejected nnz=0 save must not register metadata (partial directory)"
+    );
+    // ... and no artifact file may be left behind.
+    let artifact = storage
+        .base_path()
+        .join(format!("{name}_adjacency.lance"));
+    assert!(
+        !artifact.exists(),
+        "a rejected nnz=0 save must not leave an artifact at {artifact:?}"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_lambdas_roundtrip() {
     crate::tests::init();

--- a/tests/api_public.rs
+++ b/tests/api_public.rs
@@ -1,0 +1,54 @@
+//! #100: downstream canary for the public commit-serialization surface.
+//!
+//! This file links `genegraph-storage` as an *external* crate — the same
+//! view a consumer (genefold-vd) has. If `with_commit_actor`,
+//! `with_file_lock`, or `lock_file_for_metadata` lose their `pub`
+//! visibility, this file stops compiling.
+//!
+//! Run with `cargo test --release --test api_public`.
+
+use std::path::PathBuf;
+
+use genegraph_storage::commit::{lock_file_for_metadata, with_commit_actor, with_file_lock};
+use genegraph_storage::generations::write_json_atomic;
+
+fn scratch_dir(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "api_public_{tag}_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// The full downstream recipe for a consumer's own metadata
+/// read-modify-write cycle: cross-process advisory lock (independent CLI
+/// processes) around an in-process commit-actor cycle, publishing through
+/// the sanctioned atomic write.
+#[tokio::test]
+async fn downstream_metadata_cycle_is_publicly_composable() {
+    let dir = scratch_dir("cycle");
+    let metadata_path = dir.join("ds__g1_metadata.json");
+    write_json_atomic(&metadata_path, r#"{"v":0}"#).unwrap();
+    let lock_path = lock_file_for_metadata(&metadata_path);
+    assert_eq!(lock_path.file_name().unwrap(), "ds__g1_metadata.lock");
+
+    with_file_lock(&lock_path, || {
+        // The closure is sync (it runs on the blocking pool): a consumer's
+        // serde_json load → mutate → write_json_atomic cycle happens here.
+        Ok(())
+    })
+    .await
+    .unwrap();
+
+    // The in-process commit actor is reachable with the same shape the
+    // internal save_* registry paths use.
+    let result: genegraph_storage::StorageResult<()> =
+        with_commit_actor(&metadata_path, || async { Ok(()) }).await;
+    result.unwrap();
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/tests/api_public.rs
+++ b/tests/api_public.rs
@@ -2,14 +2,17 @@
 //!
 //! This file links `genegraph-storage` as an *external* crate — the same
 //! view a consumer (genefold-vd) has. If `with_commit_actor`,
-//! `with_file_lock`, or `lock_file_for_metadata` lose their `pub`
-//! visibility, this file stops compiling.
+//! `with_file_lock`, `with_metadata_file_lock`, or
+//! `lock_file_for_metadata` lose their `pub` visibility, this file stops
+//! compiling.
 //!
 //! Run with `cargo test --release --test api_public`.
 
 use std::path::PathBuf;
 
-use genegraph_storage::commit::{lock_file_for_metadata, with_commit_actor, with_file_lock};
+use genegraph_storage::commit::{
+    lock_file_for_metadata, with_commit_actor, with_file_lock, with_metadata_file_lock,
+};
 use genegraph_storage::generations::write_json_atomic;
 
 fn scratch_dir(tag: &str) -> PathBuf {
@@ -24,31 +27,90 @@ fn scratch_dir(tag: &str) -> PathBuf {
     dir
 }
 
-/// The full downstream recipe for a consumer's own metadata
-/// read-modify-write cycle: cross-process advisory lock (independent CLI
-/// processes) around an in-process commit-actor cycle, publishing through
-/// the sanctioned atomic write.
+/// The downstream recipe executes a real read-modify-write while BOTH
+/// locks are held: the flock is taken around the awaited commit-actor
+/// cycle, and a foreign process-shaped flock holder is excluded until the
+/// cycle completes.
 #[tokio::test]
-async fn downstream_metadata_cycle_is_publicly_composable() {
-    let dir = scratch_dir("cycle");
+async fn downstream_metadata_cycle_runs_under_both_locks() {
+    let dir = scratch_dir("composed");
     let metadata_path = dir.join("ds__g1_metadata.json");
-    write_json_atomic(&metadata_path, r#"{"v":0}"#).unwrap();
+    write_json_atomic(&metadata_path, r#"{"count":0}"#).unwrap();
+    assert_eq!(
+        lock_file_for_metadata(&metadata_path)
+            .file_name()
+            .unwrap(),
+        "ds__g1_metadata.lock"
+    );
+
+    // A foreign holder takes the lock file first, as an independent CLI
+    // process would, and parks.
     let lock_path = lock_file_for_metadata(&metadata_path);
-    assert_eq!(lock_path.file_name().unwrap(), "ds__g1_metadata.lock");
+    let (held_tx, held_rx) = std::sync::mpsc::channel::<()>();
+    let (proceed_tx, proceed_rx) = std::sync::mpsc::channel::<()>();
+    let lock_for_foreign = lock_path.clone();
+    let foreign = std::thread::spawn(move || {
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap()
+            .block_on(async {
+                with_file_lock(&lock_for_foreign, move || {
+                    held_tx.send(()).unwrap();
+                    proceed_rx.recv().unwrap();
+                    Ok(())
+                })
+                .await
+                .unwrap()
+            })
+    });
+    held_rx.recv_timeout(std::time::Duration::from_secs(5)).unwrap();
 
-    with_file_lock(&lock_path, || {
-        // The closure is sync (it runs on the blocking pool): a consumer's
-        // serde_json load → mutate → write_json_atomic cycle happens here.
-        Ok(())
-    })
-    .await
-    .unwrap();
+    // The composed cycle waits for the foreign holder, then runs its RMW
+    // (read → increment → atomic publish) under flock + commit actor.
+    let md = metadata_path.clone();
+    let md_ref = md.clone();
+    let cycle_task = tokio::spawn(async move {
+        with_metadata_file_lock(&md_ref, move || async move {
+            let mut doc: serde_json::Value =
+                serde_json::from_str(&std::fs::read_to_string(&md).unwrap()).unwrap();
+            let count = doc["count"].as_u64().unwrap();
+            doc["count"] = serde_json::json!(count + 1);
+            write_json_atomic(&md, &doc.to_string()).unwrap();
+            Ok(())
+        })
+        .await
+        .unwrap();
+    });
 
-    // The in-process commit actor is reachable with the same shape the
-    // internal save_* registry paths use.
+    // While the foreign holder parks, the composed cycle must not run its
+    // RMW (the counter file is untouched).
+    std::thread::sleep(std::time::Duration::from_millis(200));
+    assert!(
+        !cycle_task.is_finished(),
+        "composed cycle must wait for the foreign lock holder"
+    );
+
+    // Release; the cycle runs and the RMW lands.
+    proceed_tx.send(()).unwrap();
+    foreign.join().unwrap();
+    cycle_task.await.unwrap();
+    assert_eq!(
+        std::fs::read_to_string(&metadata_path).unwrap(),
+        r#"{"count":1}"#,
+        "the RMW must execute exactly once, under both locks"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The in-process commit actor remains reachable on its own for consumers
+/// that only need in-process serialization.
+#[tokio::test]
+async fn in_process_actor_cycle_is_publicly_callable() {
+    let dir = scratch_dir("actor");
+    let metadata_path = dir.join("ds__g1_metadata.json");
     let result: genegraph_storage::StorageResult<()> =
         with_commit_actor(&metadata_path, || async { Ok(()) }).await;
     result.unwrap();
-
     let _ = std::fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
Closes #100, closes #101, closes #102

## Summary

Three consumer-review follow-ups from the genefold-vd 0.28.0 adoption line (Genefold/genefold-vd#42), each landed test-first (RED confirmed before each fix).

### #100 — commit serialization for downstream consumers
- `commit::with_commit_actor` is now **public**: consumers running their own metadata read-modify-write cycles (outside the `save_*` registry paths) share the per-path in-process mailbox with the registry paths (lost-update covered by a deterministic two-cycle test).
- Blessed **cross-process** convention: `commit::with_file_lock` — advisory `flock`, hold scope = the closure (lock → RMW → publish → release), runs on the blocking pool, lock file created on demand, typed `UnsupportedFormat` off unix instead of silently skipping arbitration. Lock-file location resolves through `commit::lock_file_for_metadata` (`{metadata-stem}.lock` next to the metadata file).
- Contract documented in the `commit` module docs (with compile-checked doctests) and a README "Concurrent writers and metadata safety" section.
- New downstream canary `tests/api_public.rs` links the crate externally; any future visibility regression fails the build.

### #101 — `write_json_atomic` commit-pointer durability
- Parent directory is fsynced **after the rename**, so a crash cannot revert or lose the metadata commit pointer.
- On a freshly created parent, the new directory (and its parent) is fsynced too.
- `fsync_dir` promoted from the lancefmt writer to `generations.rs` as the single shared helper.
- Edge caught during RED: bare filenames (`parent() == Some("")`) would have regressed under a naive parent-fsync; empty parent resolves to `.` (regression-tested).

### #102 — nnz=0 sparse saves fail early and typed
- `save_sparse` rejects `nnz=0` with a typed, actionable error (`StorageError::Invalid`, "sparse 'adjacency' is fully disconnected: adjacency nnz=0 (RxC) — raise --eps/--k or gate the input before persisting") **before** the metadata commit cycle and before any artifact write — a fully disconnected adjacency (e.g. default-eps lambda-graph build) no longer leaves a partial directory.
- The lancefmt writer's empty-batch rejection stays as the format-layer backstop.
- Test-first: the reproduction test failed with exactly the reported partial-directory shape (metadata committed with `nnz=Some(0)`, then writer rejection).

## Verification

- `cargo test --release --lib` — 108 passed
- `cargo test --release --doc` — commit.rs doctests compile (external-visibility proof)
- `cargo test --release --test api_public` — downstream canary passes
- `cargo clippy --release --all-targets` — clean

New tests: `src/tests/test_commit.rs`, `tests/api_public.rs`, plus additions in `test_generations.rs` (#101) and `test_lance_layer.rs` (#102).