### PR TITLE
feat!: registry-free scalars, strict graph read, metadata-only read_schema (#107 #108 #109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## 0.61.0 (2026-09-03)
+
+Completes the registry-free collections API (#107) and makes the
+metadata-only read path first-class (#109), with an opt-in strict graph
+read mode (#108). A registry-owning consumer (genefold-vd Workstream B)
+can now save and reload scalar collections with no GeneMetadata I/O and
+no hand-written schema metadata, gate on dataset kind/stamps without a
+full columnar scan, and detect the unstamped-`num_nodes` hazard at the
+API instead of silently resizing.
+
+**Added**
+
+- `save_scalars_to_path` / `load_scalars_from_path` (#107): registry-free
+  scalar collection I/O mirroring the reader's exact contract. A single
+  non-nullable `Float64` column (neutral default name `lambda`), dataset
+  stamped `kind = vector-space`, parent dirs created, no `GeneMetadata`
+  read or write. `load_scalars` now delegates to the path-based reader.
+- `lancefmt::read_schema` (#109): metadata-only dataset read that parses
+  the flat schema (fields + KV metadata) from the newest manifest without
+  decoding any column buffers; matches `scan_all(...).schema()`. Surfaced
+  on the backend as `collection_schema_from_path` / `collection_schema`.
+- Strict graph read mode (#108): `GraphReadOptions` with a `strict` flag,
+  plus `load_graph_from_path_with_options` and the
+  `load_graph_from_path_strict` convenience variant. Strict mode rejects
+  datasets without a `num_nodes` stamp with a typed `StorageError::Invalid`
+  (instead of silently resizing to `max_id + 1`) and validates the
+  `src`/`dst`/`weight` column names, positively identifying pre-collections
+  triplet artifacts (`row`/`col`/`value`) rather than positionally coercing
+  them. The tolerant default is unchanged (the compat shim).
+
+**Changed**
+
+- `load_scalars` is now a thin delegate over `load_scalars_from_path`;
+  the kind gate and single-column/`Float64|Float32` validation are shared.
+- **Breaking**: `StorageBackend` gains the required registry-free methods
+  `save_scalars_to_path`, `load_scalars_from_path`,
+  `load_graph_from_path_with_options`, `load_graph_from_path_strict` and
+  `collection_schema_from_path` (four of which have no default
+  implementation), so external implementors of the trait must add them.
+  `collection_schema` is provided with a default implementation.
+
+Refs: #107, #108, #109, Genefold/genefold-vd#46.
+
 ## 0.60.0 (2026-09-03)
 
 First catalog-complete release line (#106): the catalog contract

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "genegraph-storage"
-version = "0.60.0"
+version = "0.61.0"
 dependencies = [
  "approx 0.5.1",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "genegraph-storage"
-version = "0.60.0"
+version = "0.61.0"
 edition = "2024"
 description = "vector database: base Lance storage"
 authors = ["Lorenzo <tunedconsulting@gmail.com>"]

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -192,6 +192,32 @@ impl GraphWriteOptions {
     }
 }
 
+/// Options for the graph read path (#108).
+///
+/// The tolerant default is the compat shim: an unstamped dataset loads with
+/// `num_nodes = max_id + 1` and columns are read positionally (name-agnostic),
+/// so pre-collections triplet artifacts still load. Strict mode makes the
+/// hazard detectable at the API instead of silently resizing.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GraphReadOptions {
+    /// When `true`, reject datasets without a `num_nodes` stamp with a typed
+    /// [`StorageError::Invalid`] instead of silently resizing to `max_id + 1`
+    /// (a graph whose trailing vertices are isolated would otherwise load
+    /// with a smaller node count than was written). Also validates the
+    /// `src`/`dst`/`weight` column names, positively identifying
+    /// pre-collections triplet artifacts (`row`/`col`/`value`) rather than
+    /// positionally coercing them.
+    pub strict: bool,
+}
+
+impl GraphReadOptions {
+    /// Strict read mode: reject unstamped `num_nodes` and validate column
+    /// names (#108).
+    pub fn strict() -> Self {
+        Self { strict: true }
+    }
+}
+
 /// A graph collection loaded back from storage (RFC #81-P3).
 #[derive(Debug, Clone, PartialEq)]
 pub struct StoredGraph {

--- a/src/lance_storage_graph.rs
+++ b/src/lance_storage_graph.rs
@@ -6,22 +6,23 @@
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
-use arrow::array::{Array as ArrowArray, Float32Array, Float64Array, UInt32Array};
-use arrow::datatypes::{DataType, Float64Type, Int64Type, UInt32Type};
+use arrow::array::{Array as ArrowArray, ArrayRef, Float32Array, Float64Array, UInt32Array};
+use arrow::datatypes::{DataType, Field, Float64Type, Int64Type, Schema, UInt32Type};
 use arrow::record_batch::RecordBatch;
 use log::{debug, info};
 use smartcore::linalg::basic::arrays::Array;
 use smartcore::linalg::basic::matrix::DenseMatrix;
 use sprs::CsMat;
 
-use crate::graph::{GraphEdge, GraphWriteOptions, StoredGraph};
+use crate::graph::{GraphEdge, GraphReadOptions, GraphWriteOptions, StoredGraph};
 use crate::metadata::FileInfo;
 use crate::metadata::GeneMetadata;
 use crate::traits::backend::StorageBackend;
 use crate::traits::lance::{
-    LanceStorage, graph_record_batch, stored_graph_from_batch, validate_vector_space_schema,
-    vector_space_collection_batch,
+    LanceStorage, graph_record_batch, stored_graph_from_batch_with_options,
+    validate_vector_space_schema, vector_space_collection_batch,
 };
 use crate::{StorageError, StorageResult};
 
@@ -1128,10 +1129,22 @@ impl StorageBackend for LanceStorageGraph {
     }
 
     async fn load_graph_from_path(&self, path: &Path) -> StorageResult<StoredGraph> {
-        info!("Loading graph collection from {:?} (registry-free)", path);
+        self.load_graph_from_path_with_options(path, &GraphReadOptions::default())
+            .await
+    }
+
+    async fn load_graph_from_path_with_options(
+        &self,
+        path: &Path,
+        options: &GraphReadOptions,
+    ) -> StorageResult<StoredGraph> {
+        info!(
+            "Loading graph collection from {:?} (registry-free, strict={})",
+            path, options.strict
+        );
         let uri = Self::path_to_uri(path)?;
         let batch = self.read_lance_all_batches_async(uri).await?;
-        let graph = stored_graph_from_batch(batch)?;
+        let graph = stored_graph_from_batch_with_options(batch, options)?;
         info!(
             "Loaded graph collection: {} edges, {} nodes, width {:?}, weight width {:?} (registry-free)",
             graph.edges.len(),
@@ -1142,10 +1155,50 @@ impl StorageBackend for LanceStorageGraph {
         Ok(graph)
     }
 
+    async fn load_graph_from_path_strict(&self, path: &Path) -> StorageResult<StoredGraph> {
+        self.load_graph_from_path_with_options(path, &GraphReadOptions::strict())
+            .await
+    }
+
     async fn load_scalars(&self, name: &str) -> StorageResult<Vec<f64>> {
-        let path = self.file_path(name);
-        info!("Loading scalar collection '{}' from {:?}", name, path);
-        let uri = Self::path_to_uri(&path)?;
+        self.load_scalars_from_path(&self.file_path(name)).await
+    }
+
+    async fn save_scalars_to_path(&self, path: &Path, values: &[f64]) -> StorageResult<()> {
+        if values.is_empty() {
+            return Err(StorageError::Invalid(
+                "empty scalar collections are not supported".into(),
+            ));
+        }
+        ensure_parent_dir(path).await?;
+        info!(
+            "Saving scalar collection ({} values) at {:?} (registry-free)",
+            values.len(),
+            path
+        );
+        // Dataset-level kind (RFC #81-P1): scalar artifacts are
+        // vector-space collections, mirroring the registry-level
+        // `CollectionKind::for_filetype("vector")` shim, so logical-kind
+        // readers (`load_scalars`) can enforce the kind (#106 review). The
+        // column name is the neutral default `lambda`.
+        let schema =
+            Schema::new(vec![Field::new("lambda", DataType::Float64, false)]).with_metadata(
+                std::collections::HashMap::from([("kind".to_string(), "vector-space".to_string())]),
+            );
+        let batch = RecordBatch::try_new(
+            Arc::new(schema),
+            vec![Arc::new(Float64Array::from(values.to_vec())) as ArrayRef],
+        )
+        .map_err(|e| StorageError::Lance(e.to_string()))?;
+        let uri = Self::path_to_uri(path)?;
+        self.write_lance_batch_async(uri, batch).await?;
+        info!("Scalar collection saved successfully (registry-free)");
+        Ok(())
+    }
+
+    async fn load_scalars_from_path(&self, path: &Path) -> StorageResult<Vec<f64>> {
+        info!("Loading scalar collection from {:?} (registry-free)", path);
+        let uri = Self::path_to_uri(path)?;
         let batch = self.read_lance_all_batches_async(uri).await?;
 
         let schema = batch.schema();
@@ -1157,7 +1210,7 @@ impl StorageBackend for LanceStorageGraph {
             Some("vector-space") => {}
             other => {
                 return Err(StorageError::Invalid(format!(
-                    "scalar collection '{name}' has dataset kind {other:?}, \
+                    "scalar collection at {path:?} has dataset kind {other:?}, \
                      expected 'vector-space'"
                 )));
             }
@@ -1203,7 +1256,15 @@ impl StorageBackend for LanceStorageGraph {
                 )));
             }
         };
-        info!("Loaded {} scalar values for '{}'", values.len(), name);
+        info!("Loaded {} scalar values (registry-free)", values.len());
         Ok(values)
+    }
+
+    async fn collection_schema_from_path(&self, path: &Path) -> StorageResult<Schema> {
+        info!("Reading collection schema from {:?} (registry-free)", path);
+        let path = path.to_path_buf();
+        tokio::task::spawn_blocking(move || crate::lancefmt::read_schema(&path))
+            .await
+            .map_err(|e| StorageError::Io(format!("lancefmt read_schema task failed: {e}")))?
     }
 }

--- a/src/lancefmt/mod.rs
+++ b/src/lancefmt/mod.rs
@@ -35,5 +35,5 @@ mod reader;
 mod schema;
 mod writer;
 
-pub use reader::scan_all;
+pub use reader::{read_schema, scan_all};
 pub use writer::write_dataset;

--- a/src/lancefmt/reader.rs
+++ b/src/lancefmt/reader.rs
@@ -791,6 +791,14 @@ fn concat_pages(pages: Vec<ArrayRef>) -> StorageResult<ArrayRef> {
     Ok(combined.column(0).clone())
 }
 
+/// Metadata-only read of a dataset directory: parses the flat schema
+/// (fields + KV metadata) from the newest manifest without decoding any
+/// column buffers (#109). The result matches `scan_all(...).schema()`.
+pub fn read_schema(dir: &Path) -> StorageResult<ArrowSchema> {
+    let manifest = open_manifest(dir)?;
+    from_lance_fields(&manifest.fields, &manifest.schema_metadata)
+}
+
 /// Full scan of a dataset directory into a single `RecordBatch`.
 pub fn scan_all(dir: &Path) -> StorageResult<RecordBatch> {
     let manifest = open_manifest(dir)?;

--- a/src/tests/test_collections.rs
+++ b/src/tests/test_collections.rs
@@ -1303,6 +1303,298 @@ async fn scalar_collections_load_via_load_scalars() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// #107: registry-free scalar collections
+// ---------------------------------------------------------------------------
+
+/// The #107 acceptance: a consumer whose metadata path holds its own
+/// metadata document saves and reloads a scalar collection (single Float64
+/// column, e.g. lambdas/norms) with no GeneMetadata read or write and no
+/// hand-written schema metadata. `load_scalars` delegates to the path-based
+/// reader.
+#[tokio::test(flavor = "multi_thread")]
+async fn registry_free_scalar_collections_roundtrip() {
+    let base = tmp_dir("registry_free_scalars").await;
+    let storage =
+        LanceStorageGraph::new(base.to_string_lossy().to_string(), "app_owned".to_string());
+
+    // the consumer's own single commit pointer at the instance metadata path
+    let app_metadata = r#"{"commit_pointer":"app__g7","format":"arrowspace"}"#;
+    tokio::fs::write(storage.metadata_path(), app_metadata)
+        .await
+        .unwrap();
+
+    let values: Vec<f64> = vec![0.0, 1.5, -2.25, f64::MIN_POSITIVE, 1.0e-300, 0.1];
+    let path = storage.file_path("lambdas");
+    storage
+        .save_scalars_to_path(&path, &values)
+        .await
+        .expect("save_scalars_to_path");
+
+    // path-based reader round-trips exact values
+    let loaded = storage
+        .load_scalars_from_path(&path)
+        .await
+        .expect("load_scalars_from_path");
+    assert_eq!(loaded.len(), values.len());
+    for (got, want) in loaded.iter().zip(values.iter()) {
+        assert_eq!(got.to_bits(), want.to_bits());
+    }
+
+    // the name-based reader delegates to the path-based one
+    let via_name = storage.load_scalars("lambdas").await.expect("load_scalars");
+    assert_eq!(via_name, loaded);
+
+    // the stamped dataset kind is vector-space, so the kind gate passes
+    let schema = crate::lancefmt::read_schema(&path).unwrap();
+    assert_eq!(
+        schema.metadata().get("kind").map(String::as_str),
+        Some("vector-space")
+    );
+
+    // the consumer's metadata document is byte-identical: no write occurred,
+    // and (being unreadable as GeneMetadata) no read occurred either
+    let after = tokio::fs::read_to_string(storage.metadata_path())
+        .await
+        .unwrap();
+    assert_eq!(after, app_metadata);
+}
+
+/// #107: empty scalar collections are rejected (mirrors the vector/graph
+/// writers), and the kind gate on the path-based reader is identical to
+/// `load_scalars` — a foreign one-column artifact is rejected.
+#[tokio::test(flavor = "multi_thread")]
+async fn registry_free_scalars_reject_empty_and_foreign() {
+    let base = tmp_dir("registry_free_scalars_invalid").await;
+    let storage =
+        LanceStorageGraph::new(base.to_string_lossy().to_string(), "app_owned".to_string());
+
+    // empty values are rejected
+    let err = storage
+        .save_scalars_to_path(&storage.file_path("empty"), &[])
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, crate::StorageError::Invalid(_)),
+        "got {err:?}"
+    );
+
+    // a foreign one-column artifact (no kind stamp) is rejected by the
+    // path-based reader, same gate as load_scalars
+    let bare = {
+        let schema = Schema::new(vec![Field::new("value", DataType::Float64, false)]);
+        RecordBatch::try_new(
+            Arc::new(schema),
+            vec![Arc::new(Float64Array::from(vec![1.0, 2.0])) as _],
+        )
+        .unwrap()
+    };
+    crate::lancefmt::write_dataset(&bare, &storage.file_path("foreign")).unwrap();
+    let err = storage
+        .load_scalars_from_path(&storage.file_path("foreign"))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, crate::StorageError::Invalid(_)),
+        "got {err:?}"
+    );
+    assert!(
+        err.to_string().contains("kind"),
+        "the rejection must name the kind mismatch: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #108: strict graph read mode
+// ---------------------------------------------------------------------------
+
+/// #108: the tolerant default (compat shim) loads an unstamped dataset with
+/// `num_nodes = max_id + 1`; strict mode rejects it with a typed error
+/// instead of silently resizing. A CSR with trailing isolated rows saved
+/// unstamped (raw writer) loads exact under tolerant mode or fails under
+/// strict — never silently resized when strict.
+#[tokio::test(flavor = "multi_thread")]
+async fn strict_graph_read_rejects_unstamped_num_nodes() {
+    let (_base, storage) = seeded_storage("strict_graph").await;
+
+    // a graph whose trailing vertices are isolated: edges only touch ids
+    // 0..3, but the true node count is 5 (ids 3 and 4 are isolated). Saved
+    // unstamped via the raw writer, so no num_nodes metadata exists.
+    let schema = Schema::new(vec![
+        Field::new("src", DataType::UInt32, false),
+        Field::new("dst", DataType::UInt32, false),
+    ]);
+    let batch = RecordBatch::try_new(
+        Arc::new(schema),
+        vec![
+            Arc::new(UInt32Array::from(vec![0u32, 1, 2])) as _,
+            Arc::new(UInt32Array::from(vec![1u32, 2, 0])) as _,
+        ],
+    )
+    .unwrap();
+    crate::lancefmt::write_dataset(&batch, &storage.file_path("unstamped")).unwrap();
+
+    // tolerant default: loads with num_nodes = max_id + 1 = 3 (the silent
+    // resize the strict mode exists to make detectable)
+    let tolerant = storage
+        .load_graph_from_path(&storage.file_path("unstamped"))
+        .await
+        .expect("tolerant load of unstamped dataset");
+    assert_eq!(tolerant.num_nodes, 3);
+
+    // strict: rejects the unstamped dataset with a typed error
+    let err = storage
+        .load_graph_from_path_strict(&storage.file_path("unstamped"))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, crate::StorageError::Invalid(_)),
+        "got {err:?}"
+    );
+    assert!(
+        err.to_string().contains("num_nodes"),
+        "the strict rejection must name the missing stamp: {err}"
+    );
+}
+
+/// #108: strict mode also validates column names — a pre-collections triplet
+/// artifact (`row`/`col`/`value`) is positively identified and rejected
+/// rather than positionally coerced into a graph collection.
+#[tokio::test(flavor = "multi_thread")]
+async fn strict_graph_read_rejects_triplet_column_names() {
+    let (_base, storage) = seeded_storage("strict_graph_triplet").await;
+
+    // a pre-collections triplet artifact (row/col/value), stamped with a
+    // num_nodes so only the column-name check is exercised
+    let schema = Schema::new(vec![
+        Field::new("row", DataType::UInt32, false),
+        Field::new("col", DataType::UInt32, false),
+        Field::new("value", DataType::Float64, false),
+    ]);
+    let batch = RecordBatch::try_new(
+        Arc::new(schema),
+        vec![
+            Arc::new(UInt32Array::from(vec![0u32, 1])) as _,
+            Arc::new(UInt32Array::from(vec![1u32, 2])) as _,
+            Arc::new(Float64Array::from(vec![1.0, 1.0])) as _,
+        ],
+    )
+    .unwrap();
+    crate::lancefmt::write_dataset(&batch, &storage.file_path("triplet")).unwrap();
+
+    // tolerant default: position-based, name-agnostic — loads as a graph
+    let tolerant = storage
+        .load_graph_from_path(&storage.file_path("triplet"))
+        .await
+        .expect("tolerant load of triplet artifact");
+    assert_eq!(tolerant.edges.len(), 2);
+
+    // strict: the column names are not src/dst/weight, so it is rejected
+    let err = storage
+        .load_graph_from_path_strict(&storage.file_path("triplet"))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, crate::StorageError::Invalid(_)),
+        "got {err:?}"
+    );
+}
+
+/// #108: a properly stamped graph (written through `save_graph*`) loads
+/// identically under tolerant and strict modes — strictness only rejects
+/// the hazard, never the well-formed artifact.
+#[tokio::test(flavor = "multi_thread")]
+async fn strict_graph_read_accepts_stamped_graph() {
+    let (_base, storage) = seeded_storage("strict_graph_stamped").await;
+    let md_path = storage.metadata_path();
+
+    let edges = generated_graph(5, 9, 7, true);
+    storage
+        .save_graph("g", &edges, &md_path)
+        .await
+        .expect("save_graph");
+
+    let tolerant = storage
+        .load_graph_from_path(&storage.file_path("g"))
+        .await
+        .expect("tolerant load");
+    let strict = storage
+        .load_graph_from_path_strict(&storage.file_path("g"))
+        .await
+        .expect("strict load of a stamped graph");
+    assert_eq!(tolerant, strict);
+    assert_eq!(strict.num_nodes, 5);
+}
+
+// ---------------------------------------------------------------------------
+// #109: lancefmt metadata-only read_schema
+// ---------------------------------------------------------------------------
+
+/// #109: `read_schema` on a dataset written by `write_dataset` returns the
+/// same schema (fields + metadata) as `scan_all(...).schema()`, with no
+/// column data parsed.
+#[tokio::test(flavor = "multi_thread")]
+async fn read_schema_matches_scan_all_without_decoding() {
+    let (_base, storage) = seeded_storage("read_schema").await;
+    let md_path = storage.metadata_path();
+
+    let edges = generated_graph(5, 9, 7, true);
+    storage
+        .save_graph("g", &edges, &md_path)
+        .await
+        .expect("save_graph");
+
+    let path = storage.file_path("g");
+    let schema = crate::lancefmt::read_schema(&path).expect("read_schema");
+    let scanned = crate::lancefmt::scan_all(&path).expect("scan_all");
+    assert_eq!(schema, *scanned.schema());
+    assert_eq!(
+        schema.metadata().get("kind").map(String::as_str),
+        Some("graph")
+    );
+    assert_eq!(
+        schema.metadata().get("num_nodes").map(String::as_str),
+        Some("5")
+    );
+    assert_eq!(schema.fields().len(), 3);
+}
+
+/// #109: missing/malformed datasets surface a typed `StorageError` (no
+/// panic), matching `scan_all`'s taxonomy.
+#[tokio::test(flavor = "multi_thread")]
+async fn read_schema_errors_on_missing_dataset() {
+    let base = tmp_dir("read_schema_missing").await;
+    let err = crate::lancefmt::read_schema(&base.join("nope")).unwrap_err();
+    assert!(matches!(err, crate::StorageError::Io(_)), "got {err:?}");
+}
+
+/// #109: the backend surfaces the metadata-only schema read so consumers
+/// don't drop to `lancefmt` directly.
+#[tokio::test(flavor = "multi_thread")]
+async fn collection_schema_surfaces_on_backend() {
+    let (_base, storage) = seeded_storage("collection_schema").await;
+    let md_path = storage.metadata_path();
+
+    let edges = generated_graph(5, 9, 7, true);
+    storage
+        .save_graph("g", &edges, &md_path)
+        .await
+        .expect("save_graph");
+
+    let schema = storage
+        .collection_schema("g")
+        .await
+        .expect("collection_schema");
+    assert_eq!(
+        schema.metadata().get("kind").map(String::as_str),
+        Some("graph")
+    );
+    assert_eq!(
+        schema.metadata().get("num_nodes").map(String::as_str),
+        Some("5")
+    );
+}
+
 /// Review PR #96 finding 4: a `kind` property that contradicts the typed
 /// `kind` field is rejected instead of silently overriding it.
 #[tokio::test(flavor = "multi_thread")]

--- a/src/traits/backend.rs
+++ b/src/traits/backend.rs
@@ -712,4 +712,62 @@ pub trait StorageBackend: Send + Sync {
     /// validity), making every `kind=vector-space` collection uniformly
     /// loadable instead of requiring the legacy fixed-key readers.
     async fn load_scalars(&self, name: &str) -> StorageResult<Vec<f64>>;
+
+    // =========
+    // #107: registry-free scalar collections
+    // =========
+
+    /// Saves a scalar collection — a single non-nullable `Float64` column
+    /// (e.g. lambdas or norms) — at an explicit `path` without touching the
+    /// metadata registry (#107): the dataset is stamped `kind=vector-space`
+    /// and parent directories are created as needed. Registry ownership
+    /// stays with the caller; no `GeneMetadata` read or write occurs. The
+    /// counterpart of [`Self::save_vectors_to_path`] for scalar-only
+    /// collections (which `save_vectors_to_path` cannot write, as its
+    /// schema validation requires a `FixedSizeList` column).
+    async fn save_scalars_to_path(&self, path: &Path, values: &[f64]) -> StorageResult<()>;
+
+    /// Loads a scalar collection from an explicit `path` (registry-free):
+    /// the path-based counterpart of [`Self::load_scalars`], with the same
+    /// kind gate. `load_scalars` delegates to this.
+    async fn load_scalars_from_path(&self, path: &Path) -> StorageResult<Vec<f64>>;
+
+    // =========
+    // #108: strict graph read mode
+    // =========
+
+    /// Loads a graph collection from an explicit `path` with read options
+    /// (#108): strict mode rejects datasets without a `num_nodes` stamp
+    /// (and, optionally, validates column names) instead of silently
+    /// resizing to `max_id + 1`. The tolerant default is the compat shim.
+    async fn load_graph_from_path_with_options(
+        &self,
+        path: &Path,
+        options: &crate::graph::GraphReadOptions,
+    ) -> StorageResult<StoredGraph>;
+
+    /// Strict variant of [`Self::load_graph_from_path`] (#108): rejects
+    /// datasets without a `num_nodes` stamp with a typed
+    /// [`StorageError::Invalid`] and validates the `src`/`dst`/`weight`
+    /// column names, so pre-collections triplet artifacts are positively
+    /// identified rather than positionally coerced.
+    async fn load_graph_from_path_strict(&self, path: &Path) -> StorageResult<StoredGraph>;
+
+    // =========
+    // #109: metadata-only schema read
+    // =========
+
+    /// Reads the dataset schema (fields + KV metadata) of a collection at
+    /// an explicit `path` without decoding any column buffers (#109): the
+    /// backend surface of [`crate::lancefmt::read_schema`], so consumers
+    /// doing kind/stamp gating don't pay a full columnar scan.
+    async fn collection_schema_from_path(&self, path: &Path) -> StorageResult<Schema>;
+
+    /// Reads the dataset schema of a named collection (registry-free,
+    /// path-resolved): the name-based counterpart of
+    /// [`Self::collection_schema_from_path`].
+    async fn collection_schema(&self, name: &str) -> StorageResult<Schema> {
+        self.collection_schema_from_path(&self.file_path(name))
+            .await
+    }
 }

--- a/src/traits/lance.rs
+++ b/src/traits/lance.rs
@@ -11,7 +11,8 @@ use log::{debug, info};
 
 use crate::catalog::RESERVED_PROPERTIES;
 use crate::graph::{
-    GraphEdge, GraphWriteOptions, NodeIdWidth, RESERVED_METADATA_KEYS, StoredGraph, WeightType,
+    GraphEdge, GraphReadOptions, GraphWriteOptions, NodeIdWidth, RESERVED_METADATA_KEYS,
+    StoredGraph, WeightType,
 };
 use crate::metadata::FileInfo;
 use crate::traits::backend::StorageBackend;
@@ -296,8 +297,16 @@ pub(crate) fn graph_record_batch(
 /// counterpart of [`graph_record_batch`], shared by `load_graph` and the
 /// registry-free `load_graph_from_path`): shared src/dst width, a
 /// `Float32|Float64` weight column (#106), lossless f32 upcasting, and
-/// the node count from dataset metadata.
-pub(crate) fn stored_graph_from_batch(batch: RecordBatch) -> StorageResult<StoredGraph> {
+/// the node count from dataset metadata. In strict mode (#108), a dataset
+/// without a `num_nodes` stamp is rejected with a typed
+/// [`StorageError::Invalid`] instead of silently resizing to `max_id + 1`,
+/// and the `src`/`dst`/`weight` column names are validated so
+/// pre-collections triplet artifacts (`row`/`col`/`value`) are positively
+/// identified rather than positionally coerced.
+pub(crate) fn stored_graph_from_batch_with_options(
+    batch: RecordBatch,
+    options: &GraphReadOptions,
+) -> StorageResult<StoredGraph> {
     let schema = batch.schema();
     let n_cols = schema.fields().len();
     if !(2..=3).contains(&n_cols) {
@@ -305,6 +314,22 @@ pub(crate) fn stored_graph_from_batch(batch: RecordBatch) -> StorageResult<Store
             "graph edge-list schema expects src/dst (and optionally weight) columns, \
              found {n_cols}"
         )));
+    }
+    // Strict column-name validation (#108): the canonical graph collection
+    // names its columns src/dst/weight; a pre-collections triplet artifact
+    // (row/col/value) is positively identified and rejected rather than
+    // positionally coerced.
+    if options.strict {
+        let expected = ["src", "dst", "weight"];
+        for (i, want) in expected.iter().enumerate().take(n_cols) {
+            if schema.field(i).name() != *want {
+                return Err(StorageError::Invalid(format!(
+                    "strict graph read: column {i} is named '{}', expected '{want}' \
+                     (a pre-collections triplet artifact?)",
+                    schema.field(i).name()
+                )));
+            }
+        }
     }
     let width = match (schema.field(0).data_type(), schema.field(1).data_type()) {
         (DataType::UInt32, DataType::UInt32) => NodeIdWidth::U32,
@@ -394,11 +419,22 @@ pub(crate) fn stored_graph_from_batch(batch: RecordBatch) -> StorageResult<Store
         .map(|(s, d)| (*s).max(*d))
         .max()
         .unwrap_or(0);
-    let num_nodes = schema
+    let stamped_num_nodes = schema
         .metadata()
         .get("num_nodes")
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(max_id + 1);
+        .and_then(|v| v.parse::<u64>().ok());
+    // Strict mode (#108): an unstamped dataset is rejected instead of
+    // silently resizing to max_id + 1 — a graph whose trailing vertices are
+    // isolated (degree-0 laplacian rows store no entries) would otherwise
+    // load with a smaller node count than was written.
+    if options.strict && stamped_num_nodes.is_none() {
+        return Err(StorageError::Invalid(format!(
+            "strict graph read: dataset has no 'num_nodes' stamp; refusing to \
+             silently resize to max_id + 1 = {}",
+            max_id + 1
+        )));
+    }
+    let num_nodes = stamped_num_nodes.unwrap_or(max_id + 1);
     let edges: Vec<GraphEdge> = match &weights {
         Some(weights) => src
             .iter()


### PR DESCRIPTION
Closes #107, #108, #109.

## #107 — Registry-free scalar collections
- `save_scalars_to_path` / `load_scalars_from_path`: registry-free scalar
  collection I/O mirroring the reader's exact contract — a single
  non-nullable `Float64` column (neutral default name `lambda`), dataset
  stamped `kind=vector-space`, parent dirs created, **no `GeneMetadata`
  read or write**.
- `load_scalars` now delegates to the path-based reader (same kind gate).

## #108 — Strict graph read mode
- `GraphReadOptions` with a `strict` flag, plus
  `load_graph_from_path_with_options` and the
  `load_graph_from_path_strict` convenience variant.
- Strict mode rejects datasets without a `num_nodes` stamp with a typed
  `StorageError::Invalid` (instead of silently resizing to `max_id + 1`)
  and validates the `src`/`dst`/`weight` column names, positively
  identifying pre-collections triplet artifacts (`row`/`col`/`value`).
- Tolerant default unchanged (the compat shim).

## #109 — lancefmt metadata-only read_schema
- `lancefmt::read_schema`: parses the flat schema (fields + KV metadata)
  from the newest manifest with no column buffers decoded; matches
  `scan_all(...).schema()`.
- Surfaced on the backend as `collection_schema_from_path` /
  `collection_schema`, so consumers doing kind/stamp gating don't pay a
  full columnar scan.

## Testing
- TDD: failing tests written first, then implementation.
- 8 new tests covering all three issues (round-trips, kind gates, strict
  rejection of unstamped/triplet artifacts, read_schema parity, backend
  surface).
- Full suite green: 131 lib + 4 integration + doc tests; clippy clean.

Bump to 0.61.0.